### PR TITLE
Add windres wrapper for LLVM tools and build pthreads on x86(64)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,12 +23,6 @@ COPY *.sh libssp-Makefile ./
 COPY wrappers/*.sh ./wrappers/
 RUN ./build-all.sh $TOOLCHAIN_PREFIX && \
     ./strip-llvm.sh $TOOLCHAIN_PREFIX && \
-    apt-get update -qq && \
-    apt-get install -qqy binutils-mingw-w64-x86-64 && \
-    cp /usr/bin/x86_64-w64-mingw32-windres $TOOLCHAIN_PREFIX/bin/x86_64-w64-mingw32-windresreal && \
-    apt-get remove -qqy binutils-mingw-w64-x86-64 && \
-    apt-get clean -y && \
-    rm -rf /var/lib/apt/lists/* && \
     rm -rf /build
 
 ENV PATH=$TOOLCHAIN_PREFIX/bin:$PATH

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -36,6 +36,10 @@ RUN ./build-mingw-w64.sh $TOOLCHAIN_PREFIX
 COPY build-compiler-rt.sh .
 RUN ./build-compiler-rt.sh $TOOLCHAIN_PREFIX
 
+# Build mingw-w64's winpthreads
+COPY build-mingw-w64-winpthreads.sh .
+RUN ./build-mingw-w64-winpthreads.sh $TOOLCHAIN_PREFIX
+
 # Build C test applications
 ENV PATH=$TOOLCHAIN_PREFIX/bin:$PATH
 

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -28,15 +28,6 @@ COPY wrappers/*.sh ./wrappers/
 COPY install-wrappers.sh .
 RUN ./install-wrappers.sh $TOOLCHAIN_PREFIX
 
-# Cheating: Pull windres from the normal binutils package.
-# llvm-rc isn't fully usable as a replacement for windres yet.
-RUN apt-get update -qq && \
-    apt-get install -qqy binutils-mingw-w64-x86-64 && \
-    cp /usr/bin/x86_64-w64-mingw32-windres $TOOLCHAIN_PREFIX/bin/x86_64-w64-mingw32-windresreal && \
-    apt-get remove -qqy binutils-mingw-w64-x86-64 && \
-    apt-get clean -y && \
-    rm -rf /var/lib/apt/lists/*
-
 # Build MinGW-w64
 COPY build-mingw-w64.sh .
 RUN ./build-mingw-w64.sh $TOOLCHAIN_PREFIX

--- a/build-all.sh
+++ b/build-all.sh
@@ -12,5 +12,6 @@ PREFIX="$1"
 ./install-wrappers.sh $PREFIX
 ./build-mingw-w64.sh $PREFIX
 ./build-compiler-rt.sh $PREFIX
+./build-mingw-w64-winpthreads.sh $PREFIX
 ./build-libcxx.sh $PREFIX
 ./build-libssp.sh $PREFIX

--- a/build-mingw-w64-winpthreads.sh
+++ b/build-mingw-w64-winpthreads.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+set -e
+
+if [ $# -lt 1 ]; then
+    echo $0 dest
+    exit 1
+fi
+PREFIX="$1"
+export PATH=$PREFIX/bin:$PATH
+
+: ${CORES:=4}
+: ${ARCHS:=${TOOLCHAIN_ARCHS-i686 x86_64}}
+
+cd mingw-w64/mingw-w64-libraries/winpthreads
+for arch in $ARCHS; do
+    mkdir -p build-$arch
+    cd build-$arch
+    ../configure --host=$arch-w64-mingw32 --prefix=$PREFIX/$arch-w64-mingw32 \
+        CC=$arch-w64-mingw32-clang AR=llvm-ar RANLIB=llvm-ranlib DLLTOOL=llvm-dlltool
+    make -j$CORES
+    make install
+    cd ..
+done
+

--- a/wrappers/windres-wrapper.sh
+++ b/wrappers/windres-wrapper.sh
@@ -85,7 +85,7 @@ INPUT=-
 OUTPUT=/dev/stdout
 INPUT_FORMAT=rc
 OUTPUT_FORMAT=coff
-CODEPAGE=
+CODEPAGE=1252
 CPP_OPTIONS=
 TARGET="$(basename $0 | sed 's/-[^-]*$//')"
 
@@ -211,7 +211,7 @@ case "${INPUT_FORMAT}" in
         done
         unset IFS
 
-        llvm-rc $RC_OPTIONS "${TMPDIR}/in.rc" /FO "${TMPDIR}/in.res"
+        llvm-rc $RC_OPTIONS "${TMPDIR}/in.rc" /C $CODEPAGE /FO "${TMPDIR}/in.res"
         case "${OUTPUT_FORMAT}" in
             "res")
                 cat "${TMPDIR}/in.res" > "${OUTPUT}"

--- a/wrappers/windres-wrapper.sh
+++ b/wrappers/windres-wrapper.sh
@@ -1,3 +1,235 @@
-#!/bin/sh
-set -e
-x86_64-w64-mingw32-windresreal "$@" --output-format res
+#!/bin/sh -e
+#
+# author: Josh de Kock <josh@itanimul.li>
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# For more information, please refer to <http://unlicense.org/>
+
+print_version () {
+    cat <<EOF >&2
+version: LLVM windres (GNU Binutils compatible) 0.1
+EOF
+    exit 1
+}
+
+print_help () {
+ cat <<EOF >&2
+usage: llvm-windres <OPTION> [INPUT-FILE] [OUTPUT-FILE]
+
+LLVM Tool to manipulate Windows resources with a GNU windres interface.
+
+Options:
+  -i, --input <arg>          Name of the input file.
+  -o, --output <arg>         Name of the output file.
+  -J, --input-format <arg>   Input format to read.
+  -O, --output-format <arg>  Output format to generate.
+  --preprocessor <arg>       Custom preprocessor command.
+  --preprocessor-arg <arg>   Preprocessor command arguments.
+  -F, --target <arg>         Target for COFF objects to be compiled for.
+  -I, --include-dir <arg>    Include directory to pass to preprocessor and resource compiler.
+  -D, --define <arg[=val]>   Define to pass to preprocessor.
+  -U, --undefine <arg[=val]> Undefine to pass to preprocessor.
+  -c, --codepage <arg>       Default codepage to use when reading an rc file (0x0-0xffff).
+  -v, --verbose              Enable verbose output.
+  -V, --version              Display version.
+  -h, --help                 Display this message and exit.
+Input Formats:
+  rc                         Text Windows Resource
+  res                        Binary Windows Resource
+Output Formats:
+  res                        Binary Windows Resource
+  coff                       COFF object
+Targets:
+  armv7-w64-mingw32
+  aarch64-w64-mingw32
+  i686-w64-mingw32
+  x86_86-w64-mingw32
+EOF
+    exit 1
+}
+
+error() {
+    echo "${PROG}: error: $1" >&2
+    exit 1
+}
+
+quote() {
+    echo "$1" | sed -e "s|'|'\\\\''|g; 1s/^/'/; \$s/\$/'/"
+}
+
+INCLUDE=
+VERBOSE=${VERBOSE:-false}
+INPUT=-
+OUTPUT=/dev/stdout
+INPUT_FORMAT=rc
+OUTPUT_FORMAT=coff
+CODEPAGE=
+CPP_OPTIONS=
+TARGET="$(basename $0 | sed 's/-[^-]*$//')"
+
+while [ $# != 0 ]; do
+    case "$1" in
+        "-i="*|"--input="*)
+            INPUT="${1#*=}";;
+        "-i"|"--input")
+            INPUT="${2}"; shift;;
+        "-o="*|"--output="*)
+            OUTPUT="${1#*=}";;
+        "-o"|"--output")
+            OUTPUT="${2}"; shift;;
+        "-J="*|"--input-format="*)
+            INPUT_FORMAT="${1#*=}";;
+        "-J"|"--input-format")
+            INPUT_FORMAT="${2}"; shift;;
+        "-O="*|"--output-format="*)
+            OUTPUT_FORMAT="${1#*=}";;
+        "-O"|"--output-format")
+            OUTPUT_FORMAT="${2}"; shift;;
+        "-F="*|"--target="*)
+            TARGET="${1#*=}";;
+        "-F"|"--target")
+            TARGET="${2}"; shift;;
+        "-I"|"--include-dir")
+            INCLUDE="${INCLUDE} ${2}"; shift;;
+        "--include-dir="*)
+            INCLUDE="${INCLUDE} ${1#*=}";;
+        "-I"*)
+            INCLUDE="${INCLUDE} ${1#-I}";;
+        "-c"|"--codepage")
+            CODEPAGE="${1#*=}";;
+        "-c="*|"--codepage="*)
+            CODEPAGE="${2}"; shift;;
+        "--preprocessor")
+            error "ENOSYS";;
+        "--preprocessor-arg")
+            error "ENOSYS";;
+        "-D"*)
+            CPP_OPTIONS="$CPP_OPTIONS $1";;
+        "-D"|"--define")
+            CPP_OPTIONS="$CPP_OPTIONS -D$2"; shift;;
+        "-v"|"--verbose")
+            VERBOSE=true;;
+        "-V"|"--version")
+            print_version;;
+        "--help"|"-h")
+            print_help;;
+        "-"*)
+            error "unrecognized option: \`$1'";;
+        *)
+            if [ "$INPUT" = "-" ]; then
+                INPUT="$1"
+            elif [ "$OUTPUT" = "/dev/stdout" ]; then
+                OUTPUT="$1"
+            else
+                error "rip: \`$1'"
+            fi
+    esac
+    shift
+done
+
+ARCH=$(echo $TARGET | sed 's/-.*//')
+case $ARCH in
+i686)    M=X86 ;;
+x86_64)  M=X64 ;;
+armv7)   M=ARM ;;
+aarch64) M=ARM64 ;;
+esac
+
+: ${CC:-$ARCH-w64-mingw32-clang}
+
+if $VERBOSE; then
+    set -x
+fi
+
+for i in $INCLUDE; do
+    CPP_OPTIONS="$CPP_OPTIONS -I$i"
+    RC_OPTIONS="$RC_OPTIONS -I $i"
+done
+
+TMPDIR="$(mktemp -d /tmp/windres.XXXXXXXXX)" || error "couldn't create temp dir"
+
+cleanup() {
+    if ! $VERBOSE; then
+        rm -rf "$TMPDIR"
+    fi
+}
+
+trap 'cleanup' EXIT
+
+case "${INPUT_FORMAT}" in
+    "rc")
+        $CC -E $(echo $CPP_OPTIONS | sed 's/\\"/"/g') -xc -DRC_INVOKED=1 "${INPUT}" -o "${TMPDIR}/post.rc" || error "preprocessor failed"
+
+        # Parse the preprocessor output, looking for source file/line markers,
+        # and discard output from *.h files. This matches what rc.exe and binutils windres
+        # do.
+        IFS='
+'
+        output=0
+        rm -f "${TMPDIR}/in.rc"
+        for line in $(cat "${TMPDIR}/post.rc"); do
+            case $line in
+            \#\ *)
+                file="$(echo "$line" | awk '{print $3}' | sed 's/^"//;s/"$//')"
+                case $file in
+                *.h)
+                    output=0
+                    ;;
+                *)
+                    output=1
+                    ;;
+                esac
+                ;;
+            *)
+                if [ $output -ne 0 ]; then
+                    echo "$line" >> "${TMPDIR}/in.rc"
+                fi
+                ;;
+            esac
+        done
+        unset IFS
+
+        llvm-rc $RC_OPTIONS "${TMPDIR}/in.rc" /FO "${TMPDIR}/in.res"
+        case "${OUTPUT_FORMAT}" in
+            "res")
+                cat "${TMPDIR}/in.res" > "${OUTPUT}"
+                ;;
+            "coff")
+                llvm-cvtres "${TMPDIR}/in.res" /MACHINE:${M} /OUT:"${TMPDIR}/out.o"
+                cat "${TMPDIR}/out.o" > "${OUTPUT}"
+                ;;
+            *)
+                error "invalid output format: \`${OUTPUT_FORMAT}'"
+        esac
+        ;;
+    "res")
+        cat "${INPUT}" > "${TMPDIR}/in.rc"
+        llvm-cvtres "${TMPDIR}/in.res" /MACHINE:${M} /FO "${TMPDIR}/out.o"
+        cat "${TMPDIR}/out.o" > "${OUTPUT}"
+        ;;
+    *)
+        error "invalid input format: \`${INPUT_FORMAT}'"
+esac
+


### PR DESCRIPTION
This is more of a PoC than anything else, it 'works', but could definitely be improved some more, was just wondering your thoughts on the approach.

Requires the following patch (to mingw-w64) for it to work, but I haven't been able to send it to the ML yet.

```patch
From ff09fbce05ef3241677e1e192112de8ab68cf7bb Mon Sep 17 00:00:00 2001
From: Josh de Kock <josh@itanimul.li>
Date: Tue, 24 Apr 2018 23:33:44 +0100
Subject: [PATCH] _mingw.h.in: guard C with RC_INVOKED

---
 mingw-w64-headers/crt/_mingw.h.in | 4 ++++
 1 file changed, 4 insertions(+)

diff --git a/mingw-w64-headers/crt/_mingw.h.in b/mingw-w64-headers/crt/_mingw.h.in
index 4c40da0c..794b7fe2 100644
--- a/mingw-w64-headers/crt/_mingw.h.in
+++ b/mingw-w64-headers/crt/_mingw.h.in
@@ -279,7 +279,9 @@ typedef int __int128 __attribute__ ((__mode__ (TI)));
 #endif
 #endif /* __nothrow */
 
+#ifndef RC_INVOKED
 #include <vadefs.h>	/* other headers depend on this include */
+#endif
 
 #ifndef _CRT_STRINGIZE
 #define __CRT_STRINGIZE(_Value) #_Value
@@ -542,6 +544,7 @@ extern "C" {
 #endif
 
 
+#ifndef RC_INVOKED
 #ifdef __MINGW_INTRIN_INLINE
 #ifdef __has_builtin
 #define __MINGW_DEBUGBREAK_IMPL !__has_builtin(__debugbreak)
@@ -559,6 +562,7 @@ __MINGW_INTRIN_INLINE void __cdecl __debugbreak(void)
 
 /* mingw-w64 specific functions: */
 const char *__mingw_get_crt_info (void);
+#endif /* RC_INVOKED */
 
 #ifdef __cplusplus
 }
-- 
2.15.1 (Apple Git-101)

```