### PR TITLE
Fix out of bound array access in native-wrappers.h

### DIFF
--- a/wrappers/native-wrapper.h
+++ b/wrappers/native-wrapper.h
@@ -88,7 +88,7 @@ static int _tspawnvp_escape(int mode, const TCHAR *filename, const TCHAR * const
     int num_args = 0;
     while (argv[num_args])
         num_args++;
-    const TCHAR **escaped_argv = malloc(num_args * sizeof(*escaped_argv));
+    const TCHAR **escaped_argv = malloc((num_args + 1) * sizeof(*escaped_argv));
     for (int i = 0; argv[i]; i++)
         escaped_argv[i] = escape(argv[i]);
     escaped_argv[num_args] = NULL;


### PR DESCRIPTION
I was seeing random crashes using the latest revision.
The array allocated in _tspawnvp_escape was too small to contain the terminating NULL.