### PR TITLE
wrappers: fix PATH not working when there are spaces in them

### DIFF
--- a/wrappers/dlltool-wrapper.sh
+++ b/wrappers/dlltool-wrapper.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 DIR="$(cd "$(dirname "$0")" && pwd)"
-export PATH=$DIR:$PATH
+export PATH="$DIR":"$PATH"
 
 BASENAME="$(basename "$0")"
 TARGET="${BASENAME%-*}"

--- a/wrappers/ld-wrapper.sh
+++ b/wrappers/ld-wrapper.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 DIR="$(cd "$(dirname "$0")" && pwd)"
-export PATH=$DIR:$PATH
+export PATH="$DIR":"$PATH"
 
 if [ "$1" = "--help" ]; then
     cat<<EOF

--- a/wrappers/objdump-wrapper.sh
+++ b/wrappers/objdump-wrapper.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 DIR="$(cd "$(dirname "$0")" && pwd)"
-export PATH=$DIR:$PATH
+export PATH="$DIR":"$PATH"
 
 if [ "$1" = "-f" ]; then
     # libtool can try to run objdump -f and wants to see certain strings in


### PR DESCRIPTION
I have some issues compiling in WSL because of that.