### PR TITLE
wrappers: don't link with vcruntime140_app

### DIFF
--- a/wrappers/clang-target-wrapper.sh
+++ b/wrappers/clang-target-wrapper.sh
@@ -74,8 +74,6 @@ mingw32uwp)
     FLAGS="$FLAGS -DUNICODE"
     # add the minimum runtime to use for UWP targets
     FLAGS="$FLAGS -Wl,-lmincore"
-    # This requires that the default crt is ucrt.
-    FLAGS="$FLAGS -Wl,-lvcruntime140_app"
     ;;
 esac
 


### PR DESCRIPTION
Using ucrt should pick the right libraries to link to instead of this old
runtime.

Tested successfully in VLC with -lucrt. The remaining calls that used
vcruntime140_app are now using api-ms-win-crt-private-l1-1-0. I think this
works since 1ace9ddd610202e232ba742e89cc99aed69b0d70 in MingW64