### PR TITLE
Update MSYS2 instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ each project for the new configure options to be taken into use.
 Building in MSYS2
 -----------------
 
-To build in MSYS2, install the following set of packages with `pacman -S`:
+To build in MSYS2, install the following set of packages with `pacman -S --needed`:
 
     git subversion mingw-w64-x86_64-gcc mingw-w64-x86_64-ninja mingw-w64-x86_64-cmake make mingw-w64-x86_64-python3
 


### PR DESCRIPTION
`pacman -S` by default reinstalls (and redownloads if necessary) packages given as arguments. Adding `--needed` flag makes it skip packages which are already installed and up to date.