### PR TITLE
Update the mingw32uwp wrapper libraries

### DIFF
--- a/wrappers/clang-target-wrapper.c
+++ b/wrappers/clang-target-wrapper.c
@@ -191,9 +191,11 @@ int _tmain(int argc, TCHAR* argv[]) {
         // the Windows Store API only supports Windows Unicode (some rare ANSI ones are available)
         exec_argv[arg++] = _T("-DUNICODE");
         // add the minimum runtime to use for UWP targets
-        exec_argv[arg++] = _T("-Wl,-lmincore");
+        exec_argv[arg++] = _T("-Wl,-lwindowsapp");
         // This requires that the default crt is ucrt.
         exec_argv[arg++] = _T("-Wl,-lvcruntime140_app");
+        // force the user of Universal C Runtime
+        exec_argv[arg++] = _T("-D_UCRT");
     }
 
     exec_argv[arg++] = _T("-target");

--- a/wrappers/clang-target-wrapper.sh
+++ b/wrappers/clang-target-wrapper.sh
@@ -73,9 +73,11 @@ mingw32uwp)
     # the Windows Store API only supports Windows Unicode (some rare ANSI ones are available)
     FLAGS="$FLAGS -DUNICODE"
     # add the minimum runtime to use for UWP targets
-    FLAGS="$FLAGS -Wl,-lmincore"
+    FLAGS="$FLAGS -Wl,-lwindowsapp"
     # This requires that the default crt is ucrt.
     FLAGS="$FLAGS -Wl,-lvcruntime140_app"
+    # Force the Universal C Runtime
+    FLAGS="$FLAGS -D_UCRT"
     ;;
 esac
 

--- a/wrappers/ld-wrapper.sh
+++ b/wrappers/ld-wrapper.sh
@@ -34,7 +34,7 @@ esac
 FLAGS="-m $M"
 case $TARGET_OS in
 mingw32uwp)
-    FLAGS="$FLAGS -lmincore -lvcruntime140_app"
+    FLAGS="$FLAGS -lwindowsapp -lvcruntime140_app"
     ;;
 esac
 ld.lld $FLAGS "$@"


### PR DESCRIPTION
- windowsapp is the preferred library when targeting Windows 10, it's safe to use it with the current mingw-w64 repo
https://docs.microsoft.com/en-us/uwp/win32-and-com/win32-apis

- ucrtbase.dll is the DLL that holds the equivalent of what was in vcruntime140_app
- `__MSVCRT_VERSION__` ensures we use the Universal C runtime