### PR TITLE
build-mingw-w64: Clone on https instead of git protocol

### DIFF
--- a/build-mingw-w64.sh
+++ b/build-mingw-w64.sh
@@ -48,7 +48,7 @@ if [ -z "$CHECKOUT_ONLY" ]; then
 fi
 
 if [ ! -d mingw-w64 ]; then
-    git clone git://git.code.sf.net/p/mingw-w64/mingw-w64
+    git clone https://git.code.sf.net/p/mingw-w64/mingw-w64
     CHECKOUT=1
 fi
 


### PR DESCRIPTION
git port is typically blocked by outbound corporate firewalls.