### PR TITLE
libssp: Download directory from gitlab instead of svn

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:18.04
 
 RUN apt-get update -qq && apt-get install -qqy --no-install-recommends \
     git wget bzip2 file unzip libtool pkg-config cmake build-essential \
-    automake yasm gettext autopoint vim python ninja-build subversion \
+    automake yasm gettext autopoint vim python ninja-build \
     ca-certificates curl less && \
     apt-get clean -y && \
     rm -rf /var/lib/apt/lists/*

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -2,7 +2,7 @@ FROM ubuntu:18.04
 
 RUN apt-get update -qq && apt-get install -qqy --no-install-recommends \
     git wget bzip2 file unzip libtool pkg-config cmake build-essential \
-    automake yasm gettext autopoint vim python ninja-build subversion \
+    automake yasm gettext autopoint vim python ninja-build \
     ca-certificates curl less && \
     apt-get clean -y && \
     rm -rf /var/lib/apt/lists/*

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Building in MSYS2
 
 To build in MSYS2, install the following set of packages with `pacman -S --needed`:
 
-    git subversion mingw-w64-x86_64-gcc mingw-w64-x86_64-ninja mingw-w64-x86_64-cmake make mingw-w64-x86_64-python3
+    git wget mingw-w64-x86_64-gcc mingw-w64-x86_64-ninja mingw-w64-x86_64-cmake make mingw-w64-x86_64-python3
 
 
 Status

--- a/build-all.sh
+++ b/build-all.sh
@@ -22,7 +22,7 @@ if [ $# -lt 1 ]; then
 fi
 PREFIX="$1"
 
-for dep in git svn cmake; do
+for dep in git wget cmake; do
     if ! hash $dep 2>/dev/null; then
         echo "$dep not installed. Please install it and retry" 1>&2
         exit 1

--- a/build-libssp.sh
+++ b/build-libssp.sh
@@ -37,7 +37,9 @@ export PATH="$PREFIX/bin:$PATH"
 : ${ARCHS:=${TOOLCHAIN_ARCHS-i686 x86_64 armv7 aarch64}}
 
 if [ ! -d libssp ]; then
-    svn checkout -q svn://gcc.gnu.org/svn/gcc/tags/gcc_7_3_0_release/libssp
+    wget -O libssp.tar.bz2 'https://gitlab.com/watched/gcc-mirror/gcc/-/archive/releases/gcc-7.3.0/gcc-releases-gcc-7.3.0.tar.bz2?path=libssp'
+    tar xf libssp.tar.bz2 --strip-components=1
+    rm -f libssp.tar.bz2
 fi
 
 cp libssp-Makefile libssp/Makefile


### PR DESCRIPTION
svn is typically blocked on corporate firewalls.