### PR TITLE
Update `windres-wrapper --version` to return 0

### DIFF
--- a/wrappers/windres-wrapper.c
+++ b/wrappers/windres-wrapper.c
@@ -73,7 +73,7 @@ static void print_version(void) {
     printf(
 "version: LLVM windres (GNU windres compatible) 0.1\n"
     );
-    exit(1);
+    exit(0);
 }
 
 static void print_help(void) {


### PR DESCRIPTION
modified:   wrappers/windres-wrapper.c - print_version now passes 0 to exit function. According to @ruki at xmake, the GNU windres program returns zero when `--version` is called.

