### PR TITLE
build-mingw-w64.sh: Switch to github mirror

### DIFF
--- a/build-mingw-w64.sh
+++ b/build-mingw-w64.sh
@@ -48,7 +48,7 @@ if [ -z "$CHECKOUT_ONLY" ]; then
 fi
 
 if [ ! -d mingw-w64 ]; then
-    git clone https://git.code.sf.net/p/mingw-w64/mingw-w64
+    git clone https://github.com/mirror/mingw-w64
     CHECKOUT=1
 fi
 


### PR DESCRIPTION
SourceForge is unstable and frequently fails in the middle of a clone, so I switched it out for the GitHub mirror instead.