### PR TITLE
Explicitly set CC to the correct compiler

### DIFF
--- a/build-mingw-w64-libraries.sh
+++ b/build-mingw-w64-libraries.sh
@@ -24,6 +24,7 @@ PREFIX="$1"
 mkdir -p "$PREFIX"
 PREFIX="$(cd "$PREFIX" && pwd)"
 export PATH="$PREFIX/bin:$PATH"
+unset CC
 
 : ${CORES:=$(nproc 2>/dev/null)}
 : ${CORES:=$(sysctl -n hw.ncpu 2>/dev/null)}

--- a/build-mingw-w64.sh
+++ b/build-mingw-w64.sh
@@ -68,6 +68,8 @@ fi
 
 export PATH="$PREFIX/bin:$PATH"
 
+unset CC
+
 : ${CORES:=$(nproc 2>/dev/null)}
 : ${CORES:=$(sysctl -n hw.ncpu 2>/dev/null)}
 : ${CORES:=4}


### PR DESCRIPTION
I encountered this while I was setting `CC` and `CXX` when running `build-all.sh`, which causes the mingw-w64 build to pick up the wrong compiler. This should fix the problem.