### PR TITLE
Update Dockerfile from ubuntu:18.04 to ubuntu:20.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:20.04
 
-RUN apt-get update -qq && apt-get install -qqy --no-install-recommends \
+RUN apt-get update -qq && DEBIAN_FRONTEND=noninteractive apt-get install -qqy --no-install-recommends \
     git wget bzip2 file unzip libtool pkg-config cmake build-essential \
     automake yasm gettext autopoint vim-tiny python3 python3-distutils \
     ninja-build ca-certificates curl less zip && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
 RUN apt-get update -qq && apt-get install -qqy --no-install-recommends \
     git wget bzip2 file unzip libtool pkg-config cmake build-essential \

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
 RUN apt-get update -qq && apt-get install -qqy --no-install-recommends \
     git wget bzip2 file unzip libtool pkg-config cmake build-essential \

--- a/release.sh
+++ b/release.sh
@@ -29,7 +29,7 @@ fi
 
 time docker build -f Dockerfile . -t mstorsjo/llvm-mingw:latest -t mstorsjo/llvm-mingw:$TAG
 
-DISTRO=ubuntu-18.04-$(uname -m)
+DISTRO=ubuntu-20.04-$(uname -m)
 docker run --rm mstorsjo/llvm-mingw:latest sh -c "cd /opt && mv llvm-mingw llvm-mingw-$TAG-ucrt-$DISTRO && tar -Jcvf - llvm-mingw-$TAG-ucrt-$DISTRO" > llvm-mingw-$TAG-ucrt-$DISTRO.tar.xz
 
 if [ -n "$NATIVEONLY" ]; then


### PR DESCRIPTION
Ubuntu 18.04 has the old version of git which is problematic with Github Actions & recursive submodules.

I think it shouldn't break anything with CI since building with libs for arm64 needs to include libraries dedicated for arm64 instead of libraries from apt-get (like `apt-get install libssl-dev` - prefix of symbols is different for every version).

PS. I built and it works:
```
Step 18/18 : ENV PATH=$TOOLCHAIN_PREFIX/bin:$PATH
 ---> Running in eb025e899eea
Removing intermediate container eb025e899eea
 ---> 40034fc44043
Successfully built 40034fc44043
Successfully tagged llvm-mingw-mod:latest
```