### PR TITLE
build-mingw-w64: Install COPYING files

### DIFF
--- a/build-mingw-w64-libraries.sh
+++ b/build-mingw-w64-libraries.sh
@@ -42,10 +42,12 @@ for lib in winpthreads winstorecompat; do
         [ -z "$CLEAN" ] || rm -rf build-$arch
         mkdir -p build-$arch
         cd build-$arch
-        ../configure --host=$arch-w64-mingw32 --prefix="$PREFIX/$arch-w64-mingw32" --libdir="$PREFIX/$arch-w64-mingw32/lib"
+        arch_prefix="$PREFIX/$arch-w64-mingw32"
+        ../configure --host=$arch-w64-mingw32 --prefix="$arch_prefix" --libdir="$arch_prefix/lib"
         make -j$CORES
         make install
         cd ..
+        install -Dm644 COPYING "$arch_prefix/share/mingw32/COPYING.${lib}.txt"
     done
     cd ..
 done

--- a/build-mingw-w64-tools.sh
+++ b/build-mingw-w64-tools.sh
@@ -92,6 +92,7 @@ cd build${CROSS_NAME}
 ../configure --prefix="$PREFIX" $CONFIGFLAGS
 $MAKE -j$CORES
 $MAKE install-strip
+install -Dm644 ../COPYING "$PREFIX/share/gendef/COPYING"
 cd ../../widl
 [ -z "$CLEAN" ] || rm -rf build${CROSS_NAME}
 mkdir -p build${CROSS_NAME}
@@ -99,6 +100,7 @@ cd build${CROSS_NAME}
 ../configure --prefix="$PREFIX" --target=$ANY_ARCH-w64-mingw32 --with-widl-includedir="$INCLUDEDIR" $CONFIGFLAGS
 $MAKE -j$CORES
 $MAKE install-strip
+install -Dm644 ../../../COPYING "$PREFIX/share/widl/COPYING"
 cd ..
 cd "$PREFIX/bin"
 # The build above produced $ANY_ARCH-w64-mingw32-widl, add symlinks to it

--- a/build-mingw-w64.sh
+++ b/build-mingw-w64.sh
@@ -124,3 +124,9 @@ for arch in $ARCHS; do
     cd ..
 done
 cd ..
+
+for arch in $ARCHS; do
+    for file in COPYING COPYING.MinGW-w64/COPYING.MinGW-w64.txt COPYING.MinGW-w64-runtime/COPYING.MinGW-w64-runtime.txt; do
+        install -Dm644 "$file" "$PREFIX/$arch-w64-mingw32/share/mingw32/$(basename "$file")"
+    done
+done


### PR DESCRIPTION
Install copyright notices into the final package. This makes LLVM MinGW
comply with many of the licenses (which require attribution), and also
makes it easier for users of LLVM MinGW to audit licenses of software
they use.