### PR TITLE
Add Control Flow Guard support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,10 +51,12 @@ jobs:
           cat versions >> $GITHUB_ENV
           mkdir -p install/llvm-mingw
           cp versions install/llvm-mingw
+          echo Enabling CFGuard when building with latest llvm and mingw-w64
+          echo CFGUARD_PARAMS=--enable-cfguard >> $GITHUB_ENV
       - name: Build
         run: |
           sudo apt-get update && sudo apt-get install ninja-build
-          ./build-all.sh $(pwd)/install/llvm-mingw --disable-clang-tools-extra --disable-lldb
+          ./build-all.sh $(pwd)/install/llvm-mingw --disable-clang-tools-extra --disable-lldb $CFGUARD_PARAMS
           cd install
           tar -Jcf ../llvm-mingw-linux.tar.xz llvm-mingw
       - uses: actions/upload-artifact@v2
@@ -89,10 +91,12 @@ jobs:
           cat versions >> $GITHUB_ENV
           mkdir -p install/llvm-mingw
           cp versions install/llvm-mingw
+          echo Enabling CFGuard when building with latest llvm and mingw-w64
+          echo CFGUARD_PARAMS=--enable-cfguard >> $GITHUB_ENV
       - name: Build
         run: |
           sudo apt-get update && sudo apt-get install ninja-build
-          ./build-all.sh $(pwd)/install/llvm-mingw --disable-clang-tools-extra --disable-lldb --enable-asserts
+          ./build-all.sh $(pwd)/install/llvm-mingw --disable-clang-tools-extra --disable-lldb --enable-asserts $CFGUARD_PARAMS
           cd install
           tar -Jcf ../llvm-mingw-linux.tar.xz llvm-mingw
       - uses: actions/upload-artifact@v2
@@ -118,6 +122,8 @@ jobs:
           . versions
           echo Building llvm-project $LLVM_VERSION mingw-w64 $MINGW_W64_VERSION
           cat versions >> $GITHUB_ENV
+          echo Enabling CFGuard when building with latest llvm and mingw-w64
+          echo CFGUARD_PARAMS=--enable-cfguard >> $GITHUB_ENV
       - uses: actions/checkout@v2
       - name: Build
         run: |
@@ -127,7 +133,7 @@ jobs:
           # (and gets picked up), but only exists in native form.
           # Disable use of zstd too - it's also available, but only in native
           # form.
-          MACOS_REDIST=1 LLVM_CMAKEFLAGS="-DLLVM_ENABLE_ZSTD=OFF" ./build-all.sh $(pwd)/install/llvm-mingw --disable-clang-tools-extra --disable-lldb
+          MACOS_REDIST=1 LLVM_CMAKEFLAGS="-DLLVM_ENABLE_ZSTD=OFF" ./build-all.sh $(pwd)/install/llvm-mingw --disable-clang-tools-extra --disable-lldb $CFGUARD_PARAMS
           cd install
           tar -Jcf ../llvm-mingw-macos.tar.xz llvm-mingw
       - uses: actions/upload-artifact@v2
@@ -181,10 +187,12 @@ jobs:
           . versions
           echo Building llvm-project $LLVM_VERSION mingw-w64 $MINGW_W64_VERSION
           cat versions >> $GITHUB_ENV
+          echo Enabling CFGuard when building with latest llvm and mingw-w64
+          echo CFGUARD_PARAMS=--enable-cfguard >> $GITHUB_ENV
       - uses: actions/checkout@v2
       - name: Build
         run: |
-          ./build-all.sh $(pwd)/install/llvm-mingw --disable-clang-tools-extra --disable-lldb
+          ./build-all.sh $(pwd)/install/llvm-mingw --disable-clang-tools-extra --disable-lldb $CFGUARD_PARAMS
           ./run-tests.sh $(pwd)/install/llvm-mingw
 
   # Use the Linux cross compilers built in the first step to cross compile

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,8 @@ ARG TOOLCHAIN_ARCHS="i686 x86_64 armv7 aarch64"
 
 ARG DEFAULT_CRT=ucrt
 
+ARG CFGUARD_ARGS=--disable-cfguard
+
 # Build everything that uses the llvm monorepo. We need to build the mingw runtime before the compiler-rt/libunwind/libcxxabi/libcxx runtimes.
 COPY build-llvm.sh build-lldb-mi.sh strip-llvm.sh install-wrappers.sh build-mingw-w64.sh build-mingw-w64-tools.sh build-compiler-rt.sh build-libcxx.sh build-mingw-w64-libraries.sh build-openmp.sh ./
 COPY wrappers/*.sh wrappers/*.c wrappers/*.h ./wrappers/
@@ -51,18 +53,18 @@ RUN ./build-llvm.sh $TOOLCHAIN_PREFIX && \
     ./build-lldb-mi.sh $TOOLCHAIN_PREFIX && \
     ./strip-llvm.sh $TOOLCHAIN_PREFIX && \
     ./install-wrappers.sh $TOOLCHAIN_PREFIX && \
-    ./build-mingw-w64.sh $TOOLCHAIN_PREFIX --with-default-msvcrt=$DEFAULT_CRT && \
+    ./build-mingw-w64.sh $TOOLCHAIN_PREFIX --with-default-msvcrt=$DEFAULT_CRT $CFGUARD_ARGS && \
     ./build-mingw-w64-tools.sh $TOOLCHAIN_PREFIX && \
-    ./build-compiler-rt.sh $TOOLCHAIN_PREFIX && \
-    ./build-libcxx.sh $TOOLCHAIN_PREFIX && \
-    ./build-mingw-w64-libraries.sh $TOOLCHAIN_PREFIX && \
+    ./build-compiler-rt.sh $TOOLCHAIN_PREFIX $CFGUARD_ARGS && \
+    ./build-libcxx.sh $TOOLCHAIN_PREFIX $CFGUARD_ARGS && \
+    ./build-mingw-w64-libraries.sh $TOOLCHAIN_PREFIX $CFGUARD_ARGS && \
     ./build-compiler-rt.sh $TOOLCHAIN_PREFIX --build-sanitizers && \
-    ./build-openmp.sh $TOOLCHAIN_PREFIX && \
+    ./build-openmp.sh $TOOLCHAIN_PREFIX $CFGUARD_ARGS && \
     rm -rf /build/*
 
 # Build libssp
 COPY build-libssp.sh libssp-Makefile ./
-RUN ./build-libssp.sh $TOOLCHAIN_PREFIX && \
+RUN ./build-libssp.sh $TOOLCHAIN_PREFIX $CFGUARD_ARGS && \
     rm -rf /build/*
 
 ENV PATH=$TOOLCHAIN_PREFIX/bin:$PATH

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -67,24 +67,26 @@ RUN ./install-wrappers.sh $TOOLCHAIN_PREFIX
 
 ARG DEFAULT_CRT=ucrt
 
+ARG CFGUARD_ARGS=--disable-cfguard
+
 # Build MinGW-w64
 COPY build-mingw-w64.sh ./
-RUN ./build-mingw-w64.sh $TOOLCHAIN_PREFIX --with-default-msvcrt=$DEFAULT_CRT
+RUN ./build-mingw-w64.sh $TOOLCHAIN_PREFIX --with-default-msvcrt=$DEFAULT_CRT $CFGUARD_ARGS
 
 COPY build-mingw-w64-tools.sh ./
 RUN ./build-mingw-w64-tools.sh $TOOLCHAIN_PREFIX
 
 # Build compiler-rt
 COPY build-compiler-rt.sh ./
-RUN ./build-compiler-rt.sh $TOOLCHAIN_PREFIX
+RUN ./build-compiler-rt.sh $TOOLCHAIN_PREFIX $CFGUARD_ARGS
 
 # Build libunwind/libcxxabi/libcxx
 COPY build-libcxx.sh ./
-RUN ./build-libcxx.sh $TOOLCHAIN_PREFIX
+RUN ./build-libcxx.sh $TOOLCHAIN_PREFIX $CFGUARD_ARGS
 
 # Build mingw-w64's extra libraries
 COPY build-mingw-w64-libraries.sh ./
-RUN ./build-mingw-w64-libraries.sh $TOOLCHAIN_PREFIX
+RUN ./build-mingw-w64-libraries.sh $TOOLCHAIN_PREFIX $CFGUARD_ARGS
 
 # Build C test applications
 ENV PATH=$TOOLCHAIN_PREFIX/bin:$PATH
@@ -152,7 +154,7 @@ RUN cd test && \
 
 # Build libssp
 COPY build-libssp.sh libssp-Makefile ./
-RUN ./build-libssp.sh $TOOLCHAIN_PREFIX
+RUN ./build-libssp.sh $TOOLCHAIN_PREFIX $CFGUARD_ARGS
 
 RUN cd test && \
     for arch in $TOOLCHAIN_ARCHS; do \
@@ -167,7 +169,7 @@ RUN cd test && \
 
 # Build OpenMP
 COPY build-openmp.sh ./
-RUN ./build-openmp.sh $TOOLCHAIN_PREFIX
+RUN ./build-openmp.sh $TOOLCHAIN_PREFIX $CFGUARD_ARGS
 
 # OpenMP on windows only supports x86.
 RUN cd test && \

--- a/build-all.sh
+++ b/build-all.sh
@@ -18,6 +18,7 @@ set -e
 
 LLVM_ARGS=""
 MINGW_ARGS=""
+CFGUARD_ARGS="--disable-cfguard"
 
 while [ $# -gt 0 ]; do
     case "$1" in
@@ -47,6 +48,12 @@ while [ $# -gt 0 ]; do
     --with-default-win32-winnt=*)
         MINGW_ARGS="$MINGW_ARGS $1"
         ;;
+    --enable-cfguard)
+        CFGUARD_ARGS="--enable-cfguard"
+        ;;
+    --disable-cfguard)
+        CFGUARD_ARGS="--disable-cfguard"
+        ;;
     *)
         if [ -n "$PREFIX" ]; then
             echo Unrecognized parameter $1
@@ -58,7 +65,7 @@ while [ $# -gt 0 ]; do
     shift
 done
 if [ -z "$PREFIX" ]; then
-    echo $0 [--enable-asserts] [--disable-dylib] [--full-llvm] [--with-python] [--symlink-projects] [--disable-lldb] [--disable-lldb-mi] [--disable-clang-tools-extra] [--host=triple] [--with-default-win32-winnt=0x601] [--with-default-msvcrt=ucrt] dest
+    echo "$0 [--enable-asserts] [--disable-dylib] [--full-llvm] [--with-python] [--symlink-projects] [--disable-lldb] [--disable-lldb-mi] [--disable-clang-tools-extra] [--host=triple] [--with-default-win32-winnt=0x601] [--with-default-msvcrt=ucrt] [--enable-cfguard|--disable-cfguard] dest"
     exit 1
 fi
 
@@ -77,11 +84,11 @@ if [ -z "$FULL_LLVM" ]; then
     ./strip-llvm.sh $PREFIX
 fi
 ./install-wrappers.sh $PREFIX
-./build-mingw-w64.sh $PREFIX $MINGW_ARGS
+./build-mingw-w64.sh $PREFIX $MINGW_ARGS $CFGUARD_ARGS
 ./build-mingw-w64-tools.sh $PREFIX
-./build-compiler-rt.sh $PREFIX
-./build-libcxx.sh $PREFIX
-./build-mingw-w64-libraries.sh $PREFIX
+./build-compiler-rt.sh $PREFIX $CFGUARD_ARGS
+./build-libcxx.sh $PREFIX $CFGUARD_ARGS
+./build-mingw-w64-libraries.sh $PREFIX $CFGUARD_ARGS
 ./build-compiler-rt.sh $PREFIX --build-sanitizers
-./build-libssp.sh $PREFIX
-./build-openmp.sh $PREFIX
+./build-libssp.sh $PREFIX $CFGUARD_ARGS
+./build-openmp.sh $PREFIX $CFGUARD_ARGS

--- a/build-compiler-rt.sh
+++ b/build-compiler-rt.sh
@@ -19,6 +19,8 @@ set -e
 SRC_DIR=../lib/builtins
 BUILD_SUFFIX=
 BUILD_BUILTINS=TRUE
+ENABLE_CFGUARD=
+CFGUARD_CFLAGS=
 
 while [ $# -gt 0 ]; do
     if [ "$1" = "--build-sanitizers" ]; then
@@ -26,14 +28,23 @@ while [ $# -gt 0 ]; do
         BUILD_SUFFIX=-sanitizers
         SANITIZERS=1
         BUILD_BUILTINS=FALSE
+    elif [ "$1" = "--enable-cfguard" ]; then
+        CFGUARD_CFLAGS="-mguard=cf"
+        ENABLE_CFGUARD=1
+    elif [ "$1" = "--disable-cfguard" ]; then
+        CFGUARD_CFLAGS=
+        ENABLE_CFGUARD=
     else
         PREFIX="$1"
     fi
     shift
 done
 if [ -z "$PREFIX" ]; then
-    echo $0 [--build-sanitizers] dest
+    echo "$0 [--build-sanitizers] [--enable-cfguard|--disable-cfguard] dest"
     exit 1
+fi
+if [ -n "$SANITIZERS" ] && [ -n "$ENABLE_CFGUARD" ]; then
+    echo "warning: Sanitizers may not work correctly with Control Flow Guard enabled." 1>&2
 fi
 
 mkdir -p "$PREFIX"
@@ -100,6 +111,8 @@ for arch in $ARCHS; do
         -DCOMPILER_RT_BUILD_BUILTINS=$BUILD_BUILTINS \
         -DLLVM_CONFIG_PATH="" \
         -DSANITIZER_CXX_ABI=libc++ \
+        -DCMAKE_C_FLAGS_INIT="$CFGUARD_CFLAGS" \
+        -DCMAKE_CXX_FLAGS_INIT="$CFGUARD_CFLAGS" \
         $SRC_DIR
     $BUILDCMD ${CORES+-j$CORES}
     $BUILDCMD install

--- a/build-compiler-rt.sh
+++ b/build-compiler-rt.sh
@@ -18,12 +18,14 @@ set -e
 
 SRC_DIR=../lib/builtins
 BUILD_SUFFIX=
+BUILD_BUILTINS=TRUE
 
 while [ $# -gt 0 ]; do
     if [ "$1" = "--build-sanitizers" ]; then
         SRC_DIR=..
         BUILD_SUFFIX=-sanitizers
         SANITIZERS=1
+        BUILD_BUILTINS=FALSE
     else
         PREFIX="$1"
     fi
@@ -95,6 +97,7 @@ for arch in $ARCHS; do
         -DCMAKE_C_COMPILER_TARGET=$arch-windows-gnu \
         -DCOMPILER_RT_DEFAULT_TARGET_ONLY=TRUE \
         -DCOMPILER_RT_USE_BUILTINS_LIBRARY=TRUE \
+        -DCOMPILER_RT_BUILD_BUILTINS=$BUILD_BUILTINS \
         -DLLVM_CONFIG_PATH="" \
         -DSANITIZER_CXX_ABI=libc++ \
         $SRC_DIR

--- a/build-libcxx.sh
+++ b/build-libcxx.sh
@@ -18,6 +18,7 @@ set -e
 
 BUILD_STATIC=ON
 BUILD_SHARED=ON
+CFGUARD_CFLAGS=
 
 while [ $# -gt 0 ]; do
     if [ "$1" = "--disable-shared" ]; then
@@ -28,13 +29,17 @@ while [ $# -gt 0 ]; do
         BUILD_STATIC=OFF
     elif [ "$1" = "--enable-static" ]; then
         BUILD_STATIC=ON
+    elif [ "$1" = "--enable-cfguard" ]; then
+        CFGUARD_CFLAGS="-mguard=cf"
+    elif [ "$1" = "--disable-cfguard" ]; then
+        CFGUARD_CFLAGS=
     else
         PREFIX="$1"
     fi
     shift
 done
 if [ -z "$PREFIX" ]; then
-    echo $0 [--disable-shared] [--disable-static] dest
+    echo "$0 [--disable-shared] [--disable-static] [--enable-cfguard|--disable-cfguard] dest"
     exit 1
 fi
 
@@ -107,6 +112,8 @@ for arch in $ARCHS; do
         -DLIBCXXABI_USE_LLVM_UNWINDER=ON \
         -DLIBCXXABI_ENABLE_SHARED=OFF \
         -DLIBCXXABI_LIBDIR_SUFFIX="" \
+        -DCMAKE_C_FLAGS_INIT="$CFGUARD_CFLAGS" \
+        -DCMAKE_CXX_FLAGS_INIT="$CFGUARD_CFLAGS" \
         ..
 
     $BUILDCMD ${CORES+-j$CORES}

--- a/build-libssp.sh
+++ b/build-libssp.sh
@@ -16,8 +16,24 @@
 
 set -e
 
-if [ $# -lt 1 ]; then
-    echo $0 dest
+CFGUARD_CFLAGS=
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+    --enable-cfguard)
+        CFGUARD_CFLAGS="-mguard=cf"
+        ;;
+    --disable-cfguard)
+        CFGUARD_CFLAGS=
+        ;;
+    *)
+        PREFIX="$1"
+        ;;
+    esac
+    shift
+done
+if [ -z "$PREFIX" ]; then
+    echo "$0 [--enable-cfguard|--disable-cfguard] dest"
     exit 1
 fi
 
@@ -26,7 +42,6 @@ if command -v gmake >/dev/null; then
     MAKE=gmake
 fi
 
-PREFIX="$1"
 mkdir -p "$PREFIX"
 PREFIX="$(cd "$PREFIX" && pwd)"
 export PATH="$PREFIX/bin:$PATH"
@@ -80,7 +95,7 @@ for arch in $ARCHS; do
     [ -z "$CLEAN" ] || rm -rf build-$arch
     mkdir -p build-$arch
     cd build-$arch
-    $MAKE -f ../Makefile -j$CORES CROSS=$arch-w64-mingw32-
+    $MAKE -f ../Makefile -j$CORES CROSS=$arch-w64-mingw32- CFGUARD_CFLAGS="$CFGUARD_CFLAGS"
     mkdir -p "$PREFIX/$arch-w64-mingw32/bin"
     cp libssp.a "$PREFIX/$arch-w64-mingw32/lib"
     cp libssp_nonshared.a "$PREFIX/$arch-w64-mingw32/lib"

--- a/build-mingw-w64-libraries.sh
+++ b/build-mingw-w64-libraries.sh
@@ -16,11 +16,26 @@
 
 set -e
 
-if [ $# -lt 1 ]; then
-    echo $0 dest
+USE_CFLAGS="-g -O2"
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+    --enable-cfguard)
+        USE_CFLAGS="-g -O2 -mguard=cf"
+        ;;
+    --disable-cfguard)
+        USE_CFLAGS="-g -O2"
+        ;;
+    *)
+        PREFIX="$1"
+        ;;
+    esac
+    shift
+done
+if [ -z "$PREFIX" ]; then
+    echo "$0 [--enable-cfguard|--disable-cfguard] dest"
     exit 1
 fi
-PREFIX="$1"
 mkdir -p "$PREFIX"
 PREFIX="$(cd "$PREFIX" && pwd)"
 export PATH="$PREFIX/bin:$PATH"
@@ -43,7 +58,9 @@ for lib in winpthreads winstorecompat; do
         mkdir -p build-$arch
         cd build-$arch
         arch_prefix="$PREFIX/$arch-w64-mingw32"
-        ../configure --host=$arch-w64-mingw32 --prefix="$arch_prefix" --libdir="$arch_prefix/lib"
+        ../configure --host=$arch-w64-mingw32 --prefix="$arch_prefix" --libdir="$arch_prefix/lib" \
+            CFLAGS="$USE_CFLAGS" \
+            CXXFLAGS="$USE_CFLAGS"
         make -j$CORES
         make install
         cd ..

--- a/build-mingw-w64.sh
+++ b/build-mingw-w64.sh
@@ -20,6 +20,8 @@ set -e
 : ${DEFAULT_MSVCRT:=ucrt}
 : ${MINGW_W64_VERSION:=d4a0c84d908243a45255a06dc293d3d7c06db98c}
 
+CFGUARD_FLAGS=
+
 while [ $# -gt 0 ]; do
     case "$1" in
     --skip-include-triplet-prefix)
@@ -31,6 +33,12 @@ while [ $# -gt 0 ]; do
     --with-default-msvcrt=*)
         DEFAULT_MSVCRT="${1#*=}"
         ;;
+    --enable-cfguard)
+        CFGUARD_FLAGS="--enable-cfguard"
+        ;;
+    --disable-cfguard)
+        CFGUARD_FLAGS=
+        ;;
     *)
         PREFIX="$1"
         ;;
@@ -39,7 +47,7 @@ while [ $# -gt 0 ]; do
 done
 if [ -z "$CHECKOUT_ONLY" ]; then
     if [ -z "$PREFIX" ]; then
-        echo $0 [--skip-include-triplet-prefix] [--with-default-win32-winnt=0x601] [--with-default-msvcrt=ucrt] dest
+        echo "$0 [--skip-include-triplet-prefix] [--with-default-win32-winnt=0x601] [--with-default-msvcrt=ucrt] [--enable-cfguard|--disable-cfguard] dest"
         exit 1
     fi
 
@@ -118,7 +126,7 @@ for arch in $ARCHS; do
         ;;
     esac
     FLAGS="$FLAGS --with-default-msvcrt=$DEFAULT_MSVCRT"
-    ../configure --host=$arch-w64-mingw32 --prefix="$PREFIX/$arch-w64-mingw32" $FLAGS
+    ../configure --host=$arch-w64-mingw32 --prefix="$PREFIX/$arch-w64-mingw32" $FLAGS $CFGUARD_FLAGS
     $MAKE -j$CORES
     $MAKE install
     cd ..

--- a/build-openmp.sh
+++ b/build-openmp.sh
@@ -16,9 +16,24 @@
 
 set -e
 
-PREFIX="$1"
+CFGUARD_CFLAGS=
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+    --enable-cfguard)
+        CFGUARD_CFLAGS="-mguard=cf"
+        ;;
+    --disable-cfguard)
+        CFGUARD_CFLAGS=
+        ;;
+    *)
+        PREFIX="$1"
+        ;;
+    esac
+    shift
+done
 if [ -z "$PREFIX" ]; then
-    echo $0 dest
+    echo "$0 [--enable-cfguard|--disable-cfguard] dest"
     exit 1
 fi
 
@@ -84,6 +99,8 @@ for arch in $ARCHS; do
         -DCMAKE_AR="$PREFIX/bin/llvm-ar" \
         -DCMAKE_RANLIB="$PREFIX/bin/llvm-ranlib" \
         -DLIBOMP_ENABLE_SHARED=TRUE \
+        -DCMAKE_C_FLAGS_INIT="$CFGUARD_CFLAGS" \
+        -DCMAKE_CXX_FLAGS_INIT="$CFGUARD_CFLAGS" \
         $CMAKEFLAGS \
         ..
     $BUILDCMD ${CORES+-j$CORES}

--- a/libssp-Makefile
+++ b/libssp-Makefile
@@ -4,7 +4,7 @@ vpath %.c $(SRC_PATH)
 CC = $(CROSS)gcc
 AR = $(CROSS)ar
 
-CFLAGS = -O2 -Wall -Wundef -I$(SRC_PATH) -D_FORTIFY_SOURCE=0 -D__SSP_FORTIFY_LEVEL=0
+CFLAGS = $(CFGUARD_CFLAGS) -O2 -Wall -Wundef -I$(SRC_PATH) -D_FORTIFY_SOURCE=0 -D__SSP_FORTIFY_LEVEL=0
 
 SOURCES = $(filter-out ssp-local.c, $(patsubst $(SRC_PATH)%,%,$(wildcard $(SRC_PATH)*.c)))
 OBJS = $(SOURCES:%.c=%.o)

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -42,6 +42,20 @@ if ! $ANY_ARCH-w64-mingw32-gcc -E is-ucrt.c > /dev/null 2>&1; then
 fi
 rm -f is-ucrt.c
 
+if (echo "int main(){}" | $ANY_ARCH-w64-mingw32-clang -x c++ - -o has-cfguard-test.exe -mguard=cf); then
+    if llvm-readobj --coff-load-config has-cfguard-test.exe | grep -q 'CF_INSTRUMENTED (0x100)'; then
+        HAS_CFGUARD=1
+    elif [ -n "$HAS_CFGUARD" ]; then
+        echo "error: Toolchain doesn't seem to include Control Flow Guard support." 1>&2
+        rm -f has-cfguard-test.exe
+        exit 1
+    fi
+    rm -f has-cfguard-test.exe
+elif [ -n "$HAS_CFGUARD" ]; then
+    echo "error: Toolchain doesn't seem to include Control Flow Guard support." 1>&2
+    exit 1
+fi
+
 : ${TARGET_OSES:=${TOOLCHAIN_TARGET_OSES-$DEFAULT_OSES}}
 
 if [ -z "$RUN_X86" ]; then
@@ -82,6 +96,9 @@ TESTS_OMP="hello-omp"
 TESTS_UWP="uwp-error"
 TESTS_IDL="idltest"
 TESTS_OTHER_TARGETS="hello"
+if [ -n "$HAS_CFGUARD" ]; then
+    TESTS_CFGUARD="cfguard-test"
+fi
 for arch in $ARCHS; do
     case $arch in
     i686|x86_64)
@@ -165,6 +182,9 @@ for arch in $ARCHS; do
         $arch-w64-mingw32-clang $test.c -o $TEST_DIR/$test.exe -fstack-protector-strong
         FAILURE_TESTS="$FAILURE_TESTS $test"
     done
+    for test in $TESTS_CFGUARD; do
+        $arch-w64-mingw32-clang $test.c -o $TEST_DIR/$test.exe -mguard=cf
+    done
     for test in $TESTS_FORTIFY; do
         $arch-w64-mingw32-clang $test.c -o $TEST_DIR/$test-fortify.exe -O2 -D_FORTIFY_SOURCE=2 -lssp
         TESTS_EXTRA="$TESTS_EXTRA $test-fortify"
@@ -216,6 +236,14 @@ for arch in $ARCHS; do
         if [ -n "$NATIVE" ]; then
             TESTS_EXTRA="$TESTS_EXTRA $test-asan"
             FAILURE_TESTS="$FAILURE_TESTS $test-asan"
+        fi
+        if [ -n "$HAS_CFGUARD" ]; then
+            # Smoke test ASAN with CFGuard to make sure it doesn't trip.
+            $arch-w64-mingw32-clang $test.c -o $TEST_DIR/$test-asan-cfguard.exe -fsanitize=address -g -gcodeview -Wl,-pdb,$TEST_DIR/$test-asan.pdb -mguard=cf
+            if [ -n "$NATIVE" ]; then
+                TESTS_EXTRA="$TESTS_EXTRA $test-asan-cfguard"
+                FAILURE_TESTS="$FAILURE_TESTS $test-asan-cfguard"
+            fi
         fi
     done
     for test in $TESTS_UBSAN; do
@@ -287,7 +315,7 @@ for arch in $ARCHS; do
                     echo $file trigger failed expectedly, returned $ret
 
                     case $test in
-                    stacksmash-asan)
+                    stacksmash-asan|stacksmash-asan-cfguard)
                         grep -q stack-buffer-overflow $OUT
                         grep -q "func.*stacksmash.c" $OUT
                         ;;
@@ -330,6 +358,22 @@ for arch in $ARCHS; do
                     rm -f $OUT
                 fi
                 i=$(($i+1))
+            done
+            for test in $TESTS_CFGUARD; do
+                file=$test.exe
+                OUT=cmdoutput
+                rm -f $OUT
+                if $RUN $test.exe check_enabled; then
+                    $RUN $test.exe normal_icall
+                    $RUN $test.exe invalid_icall_nocf || [ $? = 2 ]
+                    # We want to check the exit code to be 0xc0000409
+                    # (STATUS_STACK_BUFFER_OVERRUN aka fail fast exception).
+                    # MSYS2 bash does not give us the full 32-bit exit code, so
+                    # we have to rely on cmd.exe to perform the check.
+                    # (This probably doesn't work on Wine, but Wine doesn't
+                    # support CFG anyway, at least not for now...)
+                    $RUN cmd //v:on //c "$test.exe invalid_icall & if !errorlevel! equ -1073740791 (exit 0) else (exit 1)"
+                fi
             done
         fi
     fi

--- a/test/cfguard-test.c
+++ b/test/cfguard-test.c
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2022 Alvin Wong
+ *
+ * This file is part of llvm-mingw.
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#define WINVER 0x0603
+#define _WIN32_WINNT 0x0603
+#include <windows.h>
+
+#include <stdlib.h>
+#include <stdio.h>
+
+__attribute__ (( noinline ))
+void nop_sled_target(void) {
+    __asm__("nop"); __asm__("nop"); __asm__("nop"); __asm__("nop");
+    __asm__("nop"); __asm__("nop"); __asm__("nop"); __asm__("nop");
+    __asm__("nop"); __asm__("nop"); __asm__("nop"); __asm__("nop");
+    __asm__("nop"); __asm__("nop"); __asm__("nop"); __asm__("nop");
+
+    __asm__("nop"); __asm__("nop"); __asm__("nop"); __asm__("nop");
+    __asm__("nop"); __asm__("nop"); __asm__("nop"); __asm__("nop");
+    __asm__("nop"); __asm__("nop"); __asm__("nop"); __asm__("nop");
+    __asm__("nop"); __asm__("nop"); __asm__("nop"); __asm__("nop");
+
+#if defined(__x86_64__)
+    // On x86_64 the stack frame has to be aligned to 16 bytes. Since we
+    // skipped the prologue we need to manually realign it to prevent
+    // alignment-related crashes when calling puts() or exit().
+    __asm__("and $~0xF, %rsp");
+#endif
+
+    puts("Pwned!!!");
+
+    // We skipped the function prologue with the indirect call. If we let
+    // the function return normally it will just crash with a segfault, so
+    // do an exit instead.
+    exit(2);
+}
+
+__attribute__ (( noinline ))
+void normal_function(void) {
+    puts("Normal function called.");
+}
+
+__attribute__ (( noinline ))
+void make_indirect_call(void (*fn_ptr)(void)) {
+    fn_ptr();
+}
+
+__attribute__ (( noinline, guard(nocf) ))
+void make_indirect_call_nocf(void (*fn_ptr)(void)) {
+    fn_ptr();
+}
+
+int check_cfguard_status(void) {
+    PROCESS_MITIGATION_CONTROL_FLOW_GUARD_POLICY policy;
+    BOOL result = GetProcessMitigationPolicy(GetCurrentProcess(),
+                                             ProcessControlFlowGuardPolicy,
+                                             &policy,
+                                             sizeof(policy));
+    if (!result)
+        return 0;
+    return policy.EnableControlFlowGuard;
+}
+
+int main(int argc, char *argv[]) {
+    if (argc == 2) {
+        if (strcmp(argv[1], "check_enabled") == 0) {
+            if (check_cfguard_status()) {
+                puts("Control Flow Guard is enabled!");
+                return 0;
+            } else {
+                puts("Control Flow Guard is _not_ enabled!");
+                return 1;
+            }
+        }
+        if (strcmp(argv[1], "normal_icall") == 0) {
+            puts("Performing normal indirect call.");
+            make_indirect_call(normal_function);
+            return 0;
+        }
+        if (strcmp(argv[1], "invalid_icall") == 0) {
+            void *target = nop_sled_target;
+            target += 16;
+            puts("Performing invalid indirect call. If CFG is enabled this "
+                 "should crash with exit code 0xc0000409 (-1073740791)...");
+            fflush(stdout);
+            make_indirect_call(target);
+            puts("Unexpectedly returned from indirect call!");
+            return 1;
+        }
+        if (strcmp(argv[1], "invalid_icall_nocf") == 0) {
+            void *target = nop_sled_target;
+            target += 16;
+            puts("Performing invalid indirect call without CFG. You should "
+                 "get an exit code 2...");
+            fflush(stdout);
+            make_indirect_call_nocf(target);
+            puts("Unexpectedly returned from indirect call!");
+            return 1;
+        }
+    }
+    printf("%s ( check_enabled | normal_icall | invalid_icall | invalid_icall_nocf )\n", argv[0]);
+    return 32;
+}


### PR DESCRIPTION
Adds the option to build with Control Flow Guard support. This is disabled by default and currently only enabled for the scheduled GitHub Actions build because it requires latest LLVM 16 and mingw-w64. We should change the default to enabled for the next release.

Closes https://github.com/mstorsjo/llvm-mingw/issues/301