### PR TITLE
Fix symlink paths

### DIFF
--- a/wrappers/clang-target-wrapper.sh
+++ b/wrappers/clang-target-wrapper.sh
@@ -14,7 +14,7 @@
 # ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 # OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-DIR="$(cd "$(dirname "$0")" && pwd)"
+DIR="$(cd "$(dirname $(readlink -f "$0"))" && pwd)"
 BASENAME="$(basename "$0")"
 TARGET="${BASENAME%-*}"
 EXE="${BASENAME##*-}"

--- a/wrappers/ld-wrapper.sh
+++ b/wrappers/ld-wrapper.sh
@@ -14,7 +14,7 @@
 # ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 # OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-DIR="$(cd "$(dirname "$0")" && pwd)"
+DIR="$(cd "$(dirname $(readlink -f "$0"))" && pwd)"
 export PATH="$DIR":"$PATH"
 
 BASENAME="$(basename "$0")"

--- a/wrappers/objdump-wrapper.sh
+++ b/wrappers/objdump-wrapper.sh
@@ -14,7 +14,7 @@
 # ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 # OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-DIR="$(cd "$(dirname "$0")" && pwd)"
+DIR="$(cd "$(dirname $(readlink -f "$0"))" && pwd)"
 export PATH="$DIR":"$PATH"
 
 if [ "$1" = "-f" ]; then


### PR DESCRIPTION
This pull request fixes symlinks, symlinking `aarch64-w64-mingw32-gcc` in `/opt/homebrew/bin` for example.