### PR TITLE
wrappers: add CMake toolchain files

### DIFF
--- a/install-wrappers.sh
+++ b/install-wrappers.sh
@@ -141,6 +141,12 @@ if [ -n "$EXEEXT" ]; then
 else
     CTW_SUFFIX=.sh
 fi
+toolchainfile_path=share/cmake; toolchainfile_rev=../..
+mkdir -p "$PREFIX/$toolchainfile_path"
+sed "s,@RELPATH@,$toolchainfile_rev,g" wrappers/llvm-mingw_toolchainfile.cmake.in >"$PREFIX/$toolchainfile_path/llvm-mingw_toolchainfile.cmake"
+for arch in $ARCHS; do
+    sed "s,@ARCH@,${arch},g" wrappers/llvm-mingw_toolchainfile_arch.cmake.in >"$PREFIX/$toolchainfile_path/${arch}-w64-mingw32_toolchainfile.cmake"
+done
 cd "$PREFIX/bin"
 for arch in $ARCHS; do
     for target_os in $TARGET_OSES; do

--- a/wrappers/llvm-mingw_toolchainfile.cmake.in
+++ b/wrappers/llvm-mingw_toolchainfile.cmake.in
@@ -1,0 +1,91 @@
+# This file is Public Domain, do as you please
+
+if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.20")
+  set(_prefix "${CMAKE_CURRENT_LIST_DIR}/@RELPATH@/")
+  cmake_path(ABSOLUTE_PATH _prefix NORMALIZE)
+else()
+  get_filename_component(_prefix "${CMAKE_CURRENT_LIST_DIR}/@RELPATH@/" ABSOLUTE)
+endif()
+
+if(NOT CMAKE_SYSTEM_NAME AND NOT CMAKE_HOST_WIN32)
+  set(CMAKE_SYSTEM_NAME Windows)
+endif()
+if(NOT CMAKE_SYSTEM_PROCESSOR)
+  set(CMAKE_SYSTEM_PROCESSOR ${CMAKE_HOST_SYSTEM_PROCESSOR})
+  if(CMAKE_HOST_WIN32)
+    # inspect clang's default target architecture
+    execute_process(COMMAND "${_prefix}bin/clang.exe" -dumpmachine
+      RESULT_VARIABLE cresult
+      OUTPUT_VARIABLE _respath
+      OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+    if(NOT cresult EQUAL 0)
+      message(FATAL_ERROR "\"${_prefix}bin/clang.exe\" -dumpmachine: failed with ${cresult}")
+    endif()
+    unset(cresult)
+    string(REGEX REPLACE "-.*" "" CMAKE_SYSTEM_PROCESSOR "${_respath}")
+    # If you encounter build/runtime issues, this might be relevant information
+    message(VERBOSE "llvm-toolchainfile: using Target CPU ${CMAKE_SYSTEM_PROCESSOR} on Host CPU ${CMAKE_HOST_SYSTEM_PROCESSOR}")
+  endif()
+endif()
+
+set(CMAKE_SYSROOT "${_prefix}${CMAKE_SYSTEM_PROCESSOR}-w64-mingw32")
+
+# cmake-style list of paths
+set(_respath "${CMAKE_SYSROOT}/lib/pkgconfig" "${CMAKE_SYSROOT}/share/pkgconfig")
+
+if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.20")
+  cmake_path(CONVERT "${_respath}" TO_NATIVE_PATH_LIST _respath)
+  set(ENV{PKG_CONFIG_LIBDIR} "${_respath}")
+  cmake_path(NATIVE_PATH CMAKE_SYSROOT _respath)
+  set(ENV{PKG_CONFIG_SYSROOT_DIR} "${_respath}")
+else()
+  if(CMAKE_HOST_WIN32)
+    file(TO_NATIVE_PATH "${_respath}" _respath)
+  else()
+    string(REPLACE ";" ":" _respath "${_respath}")
+  endif()
+  set(ENV{PKG_CONFIG_LIBDIR} "${_respath}")
+  file(TO_NATIVE_PATH "${CMAKE_SYSROOT}" _respath)
+  set(ENV{PKG_CONFIG_SYSROOT_DIR} "${_respath}")
+endif()
+
+# set these before find_program!
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)
+
+set(_linker lld)
+set(_exesuff)
+if(CMAKE_HOST_WIN32)
+set(_exesuff .exe)
+endif()
+set(CMAKE_ASM_COMPILER "${_prefix}bin/clang${_exesuff}")
+set(CMAKE_C_COMPILER "${_prefix}bin/clang${_exesuff}")
+set(CMAKE_CXX_COMPILER "${_prefix}bin/clang++${_exesuff}")
+set(CMAKE_RC_COMPILER "${_prefix}bin/llvm-rc${_exesuff}")
+set(CMAKE_LINKER "${_prefix}bin/ld.${_linker}${_exesuff}")
+unset(_exesuff)
+
+unset(_prefix)
+unset(_respath)
+
+set(CMAKE_C_COMPILER_TARGET ${CMAKE_SYSTEM_PROCESSOR}-w64-mingw32)
+set(CMAKE_CXX_COMPILER_TARGET ${CMAKE_C_COMPILER_TARGET})
+set(CMAKE_ASM_COMPILER_TARGET ${CMAKE_C_COMPILER_TARGET})
+
+set(CMAKE_CXX_FLAGS_INIT "-stdlib=libc++")
+
+if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.29")
+  string(TOUPPER ${_linker} CMAKE_LINKER_TYPE)
+  set(_linker)
+else()
+  set(_linker " -fuse-ld=${_linker}")
+endif()
+
+# CMAKE_CXX_FLAGS is automatically added now, but might be needed to add -stdlib=libc++ for really old CMake Versions
+set(CMAKE_EXE_LINKER_FLAGS_INIT "--start-no-unused-arguments -rtlib=compiler-rt -unwindlib=libunwind --end-no-unused-arguments${_linker}")
+set(CMAKE_MODULE_LINKER_FLAGS_INIT "${CMAKE_EXE_LINKER_FLAGS_INIT}")
+set(CMAKE_SHARED_LINKER_FLAGS_INIT "${CMAKE_EXE_LINKER_FLAGS_INIT}")
+unset(_linker)

--- a/wrappers/llvm-mingw_toolchainfile_arch.cmake.in
+++ b/wrappers/llvm-mingw_toolchainfile_arch.cmake.in
@@ -1,0 +1,9 @@
+# This file is Public Domain, do as you please
+
+if(NOT CMAKE_SYSTEM_NAME)
+  set(CMAKE_SYSTEM_NAME Windows)
+endif()
+
+set(CMAKE_SYSTEM_PROCESSOR @ARCH@)
+
+include("${CMAKE_CURRENT_LIST_DIR}/llvm-mingw_toolchainfile.cmake")


### PR DESCRIPTION
Those toolchain files greatly simplify configuring a project to use the llvm-mingw toolchain.

The toolchain file will:

-   Configure CMake to look for libraries and headers in the correct directories
-   Configure Clang for the architecture, `libc++` and `lld`
-   Locate the *primary* Compiler executable

CMake has some quite complete and complex machinery to detect further tools
and configuration. Whatever supported in your CMake version should "just work" (eg. C++ Modules one day).

The lookup uses the system clang toolchain as fallback, and does not require any of the wrappers / symlinks in `bin`.
ie. Its possible to delete the `bin` directory if a matching clang/llvm toolchain is installed.