### PR TITLE
WIP: Prepare for running tests on Windows on ARM

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -627,7 +627,15 @@ jobs:
   test-ffmpeg:
     if: (github.event_name == 'schedule') && (github.repository == 'mstorsjo/llvm-mingw')
     needs: [linux-cross-windows]
-    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        arch:
+          - i686
+          - x86_64
+          - armv7
+          - aarch64
+    runs-on: ${{startsWith(matrix.arch, 'a') && 'windows-11-arm' || 'windows-latest'}}
     defaults:
       run:
         shell: msys2 {0}
@@ -666,7 +674,7 @@ jobs:
           export PATH=/llvm-mingw/bin:$PATH
           mkdir ffmpeg-build
           cd ffmpeg-build
-          ../ffmpeg/configure --samples=../fate-samples --enable-gpl
+          ../ffmpeg/configure --arch=${{matrix.arch}} --samples=../fate-samples --enable-gpl
           make -j$(nproc)
           make fate-rsync
           make -j$(nproc) fate

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -366,7 +366,7 @@ jobs:
           ./run-tests.sh /llvm-mingw
           ./run-lldb-tests.sh /llvm-mingw
 
-  # Run libcxx's tests with the cross-built i686/x86_64 toolchains from above.
+  # Run libcxx's tests with the cross-built toolchains from above.
   # (This builds its own copy of libcxx, but it should be pretty much
   # identical to the one shipped - and tests that the toolchain works
   # for running the libcxx tests.)
@@ -380,13 +380,15 @@ jobs:
     # temporarily on a branch for testing.
     if: false
     needs: [linux-cross-windows, prepare]
-    runs-on: windows-latest
     strategy:
       fail-fast: false
       matrix:
         include:
-          - { arch: x86_64, prefix: i686-w64-mingw32- }
-          - { arch: x86_64, prefix: }
+          - { arch: x86_64,  target_arch: i686    }
+          - { arch: x86_64,  target_arch: x86_64  }
+          - { arch: aarch64, target_arch: armv7   }
+          - { arch: aarch64, target_arch: aarch64 }
+    runs-on: ${{startsWith(matrix.arch, 'a') && 'windows-11-arm' || 'windows-latest'}}
     steps:
       - name: Install dependencies
         run: |
@@ -420,8 +422,9 @@ jobs:
             -DLIBCXX_ENABLE_WERROR=YES `
             -DLLVM_ENABLE_RUNTIMES="libcxx;libcxxabi;libunwind" `
             -DLIBCXX_CXX_ABI=libcxxabi `
-            -DCMAKE_C_COMPILER=${{matrix.prefix}}clang `
-            -DCMAKE_CXX_COMPILER=${{matrix.prefix}}clang++ `
+            -DCMAKE_C_COMPILER=${{matrix.target_arch}}-w64-mingw32-clang `
+            -DCMAKE_CXX_COMPILER=${{matrix.target_arch}}-w64-mingw32-clang++ `
+            -DCMAKE_CXX_COMPILER_TARGET=${{matrix.target_arch}}-w64-windows-gnu `
             -DLIBCXXABI_ENABLE_SHARED=NO `
             -DLIBCXX_ENABLE_STATIC_ABI_LIBRARY=YES `
             -DLIBCXX_USE_COMPILER_RT=YES `
@@ -432,7 +435,7 @@ jobs:
             -DCMAKE_INSTALL_MESSAGE=NEVER `
             -DLLVM_LIT_ARGS="-v --time-tests"
           ninja
-          ninja check-cxx check-cxxabi check-unwind
+          ninja ${{startsWith(matrix.arch, 'a') && 'check-cxx' || 'check-cxx check-cxxabi check-unwind'}}
 
   # Run the OpenMP tests with the cross-built i686/x86_64 toolchains from above.
   # This also forces testing the bundled python executables.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -332,7 +332,6 @@ jobs:
   test-toolchain:
     if: (github.event_name != 'schedule') || (github.repository == 'mstorsjo/llvm-mingw')
     needs: [linux-cross-windows]
-    runs-on: windows-latest
     defaults:
       run:
         shell: msys2 {0}
@@ -342,6 +341,9 @@ jobs:
         arch:
           - x86_64
           - i686
+          - armv7
+          - aarch64
+    runs-on: ${{startsWith(matrix.arch, 'a') && 'windows-11-arm' || 'windows-latest'}}
     steps:
       - uses: msys2/setup-msys2@v2
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -437,19 +437,21 @@ jobs:
           ninja
           ninja ${{startsWith(matrix.arch, 'a') && 'check-cxx' || 'check-cxx check-cxxabi check-unwind'}}
 
-  # Run the OpenMP tests with the cross-built i686/x86_64 toolchains from above.
+  # Run the OpenMP tests with the cross-built toolchains from above.
   # This also forces testing the bundled python executables.
   test-openmp:
     # Only running these tests in scheduled builds.
     if: (github.event_name == 'schedule') && (github.repository == 'mstorsjo/llvm-mingw')
     needs: [linux-cross-windows, prepare]
-    runs-on: windows-latest
     strategy:
       fail-fast: false
       matrix:
         include:
           - { arch: i686, asmflag: }
           - { arch: x86_64, asmflag: -m64 }
+          - { arch: armv7 }
+          - { arch: aarch64 }
+    runs-on: ${{startsWith(matrix.arch, 'a') && 'windows-11-arm' || 'windows-latest'}}
     steps:
       - name: Install dependencies
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
   # slightly more, when we know a separate build of the same version but with
   # assertions enabled, has passed some amount of tests.
   prepare:
-    if: (github.event_name != 'schedule') || (github.repository == 'mstorsjo/llvm-mingw')
+    if: false
     runs-on: ubuntu-latest
     outputs:
       LLVM_VERSION: ${{steps.get-versions.outputs.LLVM_VERSION}}
@@ -66,7 +66,7 @@ jobs:
 
   # Build a cross compiler for Linux, targeting Windows.
   linux:
-    if: (github.event_name != 'schedule') || (github.repository == 'mstorsjo/llvm-mingw')
+    if: false
     needs: [prepare]
     runs-on: ubuntu-22.04
     steps:
@@ -102,7 +102,7 @@ jobs:
   # Crosscompile the toolchain for running on Linux on a different architecture, bundle the runtime
   # libraries that were built in the 'linux' step above.
   linux-cross-aarch64:
-    if: (github.event_name != 'schedule') || (github.repository == 'mstorsjo/llvm-mingw')
+    if: false
     needs: [linux, prepare]
     runs-on: ubuntu-22.04
     steps:
@@ -157,7 +157,7 @@ jobs:
   # to better catch such bugs early. This makes the first-stage toolchain built
   # here in scheduled builds somewhat slower.
   linux-asserts:
-    if: (github.event_name == 'schedule') && (github.repository == 'mstorsjo/llvm-mingw')
+    if: false
     needs: [prepare]
     runs-on: ubuntu-latest
     steps:
@@ -187,7 +187,7 @@ jobs:
 
   # Build a cross compiler for macOS, targeting Windows.
   macos:
-    if: (github.event_name != 'schedule') || (github.repository == 'mstorsjo/llvm-mingw')
+    if: false
     needs: [prepare]
     runs-on: macos-14
     steps:
@@ -225,7 +225,7 @@ jobs:
   # environments). The binaries built here rely on the runtime libraries from
   # the host environment (libstdc++ or libc++).
   msys2:
-    if: (github.event_name != 'schedule') || (github.repository == 'mstorsjo/llvm-mingw')
+    if: false
     needs: [prepare]
     runs-on: windows-latest
     defaults:
@@ -282,7 +282,7 @@ jobs:
   # llvm and make a proper standalone toolchain for Windows (for all 4
   # architectures). The binaries built here match actual releases quite closely.
   linux-cross-windows:
-    if: (github.event_name != 'schedule') || (github.repository == 'mstorsjo/llvm-mingw')
+    if: false
     needs: [linux, prepare]
     runs-on: ubuntu-latest
     strategy:
@@ -331,7 +331,6 @@ jobs:
   # toolchains from above.
   test-toolchain:
     if: (github.event_name != 'schedule') || (github.repository == 'mstorsjo/llvm-mingw')
-    needs: [linux-cross-windows]
     defaults:
       run:
         shell: msys2 {0}
@@ -351,11 +350,9 @@ jobs:
           install: >-
             unzip
             make
-      - uses: actions/download-artifact@v4
-        with:
-          name: windows-ucrt-${{matrix.arch}}-toolchain
       - name: Unpack toolchain
         run: |
+          curl -LO https://github.com/mstorsjo/llvm-mingw/releases/download/20250417/llvm-mingw-20250417-ucrt-${{matrix.arch}}.zip
           unzip -q llvm-mingw-*.zip
           rm llvm-mingw-*.zip
           mv llvm-mingw-* /llvm-mingw
@@ -378,8 +375,7 @@ jobs:
     # testing with the latest compiler instead of an older release).
     # Therefore, keep the test disabled by default; it's easy to enable
     # temporarily on a branch for testing.
-    if: false
-    needs: [linux-cross-windows, prepare]
+    if: true
     strategy:
       fail-fast: false
       matrix:
@@ -393,11 +389,9 @@ jobs:
       - name: Install dependencies
         run: |
           choco install ninja
-      - uses: actions/download-artifact@v4
-        with:
-          name: windows-ucrt-${{matrix.arch}}-toolchain
       - name: Unpack toolchain
         run: |
+          curl -LO https://github.com/mstorsjo/llvm-mingw/releases/download/20250417/llvm-mingw-20250417-ucrt-${{matrix.arch}}.zip
           Expand-Archive llvm-mingw-*.zip -DestinationPath .
           del llvm-mingw-*.zip
           mv llvm-mingw-* c:\llvm-mingw
@@ -441,8 +435,7 @@ jobs:
   # This also forces testing the bundled python executables.
   test-openmp:
     # Only running these tests in scheduled builds.
-    if: (github.event_name == 'schedule') && (github.repository == 'mstorsjo/llvm-mingw')
-    needs: [linux-cross-windows, prepare]
+    if: true
     strategy:
       fail-fast: false
       matrix:
@@ -456,11 +449,9 @@ jobs:
       - name: Install dependencies
         run: |
           choco install ninja
-      - uses: actions/download-artifact@v4
-        with:
-          name: windows-ucrt-${{matrix.arch}}-toolchain
       - name: Unpack toolchain
         run: |
+          curl -LO https://github.com/mstorsjo/llvm-mingw/releases/download/20250417/llvm-mingw-20250417-ucrt-${{matrix.arch}}.zip
           Expand-Archive llvm-mingw-*.zip -DestinationPath .
           del llvm-mingw-*.zip
           mv llvm-mingw-* c:\llvm-mingw
@@ -508,7 +499,7 @@ jobs:
   # above. This also forces testing the bundled python executables.
   test-compiler-rt:
     # Only running these tests in scheduled builds.
-    if: (github.event_name == 'schedule') && (github.repository == 'mstorsjo/llvm-mingw')
+    if: false
     needs: [linux-cross-windows, prepare]
     runs-on: windows-latest
     strategy:
@@ -587,7 +578,7 @@ jobs:
   # enabled, to catch code generation bugs that might trigger asserts, to
   # find such regressions early.
   linux-test-cross-build-ffmpeg:
-    if: (github.event_name == 'schedule') && (github.repository == 'mstorsjo/llvm-mingw')
+    if: false
     needs: [linux-asserts]
     runs-on: ubuntu-latest
     strategy:
@@ -632,8 +623,7 @@ jobs:
   # compiler itself, but that only show up at runtime. This is only done
   # for scheduled builds.
   test-ffmpeg:
-    if: (github.event_name == 'schedule') && (github.repository == 'mstorsjo/llvm-mingw')
-    needs: [linux-cross-windows]
+    if: true
     strategy:
       fail-fast: false
       matrix:
@@ -661,11 +651,9 @@ jobs:
             diffutils
           pacboy: >-
             nasm:p
-      - uses: actions/download-artifact@v4
-        with:
-          name: windows-ucrt-x86_64-toolchain
       - name: Unpack toolchain
         run: |
+          curl -LO https://github.com/mstorsjo/llvm-mingw/releases/download/20250417/llvm-mingw-20250417-ucrt-${{matrix.arch}}.zip
           unzip -q llvm-mingw-*.zip
           rm llvm-mingw-*.zip
           mv llvm-mingw-* /llvm-mingw
@@ -687,7 +675,7 @@ jobs:
           make -j$(nproc) fate
 
   upload-nightly:
-    if: (github.event_name == 'schedule') && (github.repository == 'mstorsjo/llvm-mingw')
+    if: false
     permissions:
       contents: write
     needs: [linux, linux-cross-aarch64, macos, linux-cross-windows, test-toolchain, linux-test-cross-build-ffmpeg, test-ffmpeg]

--- a/.github/workflows/test-libcxx.yml
+++ b/.github/workflows/test-libcxx.yml
@@ -41,13 +41,15 @@ jobs:
 
   test-libcxx:
     needs: [prepare]
-    runs-on: windows-latest
     strategy:
       fail-fast: false
       matrix:
         include:
-          - { arch: x86_64, prefix: i686-w64-mingw32- }
-          - { arch: x86_64, prefix: }
+          - { arch: x86_64,  target_arch: i686    }
+          - { arch: x86_64,  target_arch: x86_64  }
+          - { arch: aarch64, target_arch: armv7   }
+          - { arch: aarch64, target_arch: aarch64 }
+    runs-on: ${{startsWith(matrix.arch, 'a') && 'windows-11-arm' || 'windows-latest'}}
     steps:
       - name: Install dependencies
         run: |
@@ -87,8 +89,9 @@ jobs:
             -DLIBCXX_ENABLE_WERROR=YES `
             -DLLVM_ENABLE_RUNTIMES="libcxx;libcxxabi;libunwind" `
             -DLIBCXX_CXX_ABI=libcxxabi `
-            -DCMAKE_C_COMPILER=${{matrix.prefix}}clang `
-            -DCMAKE_CXX_COMPILER=${{matrix.prefix}}clang++ `
+            -DCMAKE_C_COMPILER=${{matrix.target_arch}}-w64-mingw32-clang `
+            -DCMAKE_CXX_COMPILER=${{matrix.target_arch}}-w64-mingw32-clang++ `
+            -DCMAKE_CXX_COMPILER_TARGET=${{matrix.target_arch}}-w64-windows-gnu `
             -DLIBCXXABI_ENABLE_SHARED=NO `
             -DLIBCXX_ENABLE_STATIC_ABI_LIBRARY=YES `
             -DLIBCXX_USE_COMPILER_RT=YES `
@@ -99,4 +102,4 @@ jobs:
             -DCMAKE_INSTALL_MESSAGE=NEVER `
             -DLLVM_LIT_ARGS="-v --time-tests"
           ninja
-          ninja check-cxx check-cxxabi check-unwind
+          ninja ${{startsWith(matrix.arch, 'a') && 'check-cxx' || 'check-cxx check-cxxabi check-unwind'}}


### PR DESCRIPTION
CC @jeremyd2019 - I tried to incorporate your great suggestions on how to detect what architectures we can execute here - please take a look! (I would probably squash away at least some of the earlier attempts in the end, but I'm including all the variants I've tried so far.) At the same time I'm also making it much nicer for detecting what tests we can execute on WSL and Unix as well (by detecting whether Wine is available, for aarch64 too).

Once we're aligned on how to fix up the scripts, I would probably merge those bits soon (so that they'd be included in the next tagged version of llvm-mingw). Then for actually running these tests on windows-arm in each pipeline in master, I'm not sure if we should wait a bit longer in case there are stability issues with it. But it's good to prepare and gear up for running these things!