### PR TITLE
Add initial ARM64EC support

### DIFF
--- a/build-mingw-w64.sh
+++ b/build-mingw-w64.sh
@@ -121,7 +121,7 @@ for arch in $ARCHS; do
     armv7)
         FLAGS="--disable-lib32 --disable-lib64 --enable-libarm32"
         ;;
-    aarch64)
+    aarch64|arm64ec)
         FLAGS="--disable-lib32 --disable-lib64 --enable-libarm64"
         ;;
     i686)

--- a/build-openmp.sh
+++ b/build-openmp.sh
@@ -70,6 +70,10 @@ for arch in $ARCHS; do
     x86_64)
         CMAKEFLAGS="$CMAKEFLAGS -DLIBOMP_ASMFLAGS=-m64"
         ;;
+    arm64ec)
+        # Not yet supported
+        continue
+        ;;
     esac
 
     [ -z "$CLEAN" ] || rm -rf build-$arch


### PR DESCRIPTION
Both LLVM and mingw-w64 now have sufficient ARM64EC support to build a functional toolchain. This PR adds the necessary llvm-mingw tweaks. With these changes, it's possible to build the toolchain using:
```
ARCHS="i686 x86_64 armv7 aarch64 arm64ec" LLVM_VERSION=main ./build-all.sh
```