### PR TITLE
strip-llvm: Make sure the $PREFIX directory exists.

### DIFF
--- a/strip-llvm.sh
+++ b/strip-llvm.sh
@@ -33,6 +33,8 @@ if [ -z "$PREFIX" ]; then
     echo $0 [--host=triple] dir
     exit 1
 fi
+
+mkdir -p "$PREFIX"
 cd "$PREFIX"
 
 if [ -n "$FULL_LLVM" ]; then


### PR DESCRIPTION
I tried running `build-all.sh --disable-lldb-mi` and encountered this. Usually this directory gets created by `build-lldb-mi.sh`.