### PR TITLE
fix: repair check if existing clang supports CFG

### DIFF
--- a/build-all.sh
+++ b/build-all.sh
@@ -136,7 +136,7 @@ for dep in git cmake ${HOST_CLANG}; do
 done
 
 if [ -n "${HOST_CLANG}" ] && [ "${CFGUARD_ARGS}" = "--enable-cfguard"  ]; then
-    "${HOST_CLANG}" -c -x c -o - - -Werror -mguard=cf </dev/null >/dev/null 2>/dev/null || CFGUARD_ARGS="--disable-cfguard"
+    "${HOST_CLANG}" -target x86_64-w64-mingw32 -c -x c -o - - -Werror -mguard=cf </dev/null >/dev/null 2>/dev/null || CFGUARD_ARGS="--disable-cfguard"
 fi
 
 if [ -n "$FULL_PGO" ]; then


### PR DESCRIPTION
An existing clang might support Control flow guard, but does so only for Windows targets.