### PR TITLE
install-wrappers: add symlinks for LLVM triples

### DIFF
--- a/install-wrappers.sh
+++ b/install-wrappers.sh
@@ -126,6 +126,8 @@ cp wrappers/*-wrapper.sh "$PREFIX/bin"
 cp wrappers/mingw32-common.cfg $PREFIX/bin
 for arch in $ARCHS; do
     cp wrappers/$arch-w64-windows-gnu.cfg $PREFIX/bin
+    # Also accept `--target=$arch-pc-windows-gnu` style arg
+    ln -sf $arch-w64-windows-gnu.cfg $PREFIX/bin/$arch-pc-windows-gnu.cfg
 done
 if [ -n "$HOST" ] && [ -n "$EXEEXT" ]; then
     # TODO: If building natively on msys, pick up the default HOST value from there.


### PR DESCRIPTION
Fixes #493

After this change:
```
❯ ls build/bin/*.cfg
lrwxrwxrwx  - mateusz 17 lis 20:49 󱁻 build/bin/aarch64-pc-windows-gnu.cfg -> aarch64-w64-windows-gnu.cfg
.rw-r--r-- 82 mateusz 17 lis 20:49 󱁻 build/bin/aarch64-w64-windows-gnu.cfg
lrwxrwxrwx  - mateusz 17 lis 20:49 󱁻 build/bin/arm64ec-pc-windows-gnu.cfg -> arm64ec-w64-windows-gnu.cfg
.rw-r--r-- 82 mateusz 17 lis 20:49 󱁻 build/bin/arm64ec-w64-windows-gnu.cfg
lrwxrwxrwx  - mateusz 17 lis 20:49 󱁻 build/bin/armv7-pc-windows-gnu.cfg -> armv7-w64-windows-gnu.cfg
.rw-r--r-- 78 mateusz 17 lis 20:49 󱁻 build/bin/armv7-w64-windows-gnu.cfg
lrwxrwxrwx  - mateusz 17 lis 20:49 󱁻 build/bin/i686-pc-windows-gnu.cfg -> i686-w64-windows-gnu.cfg
.rw-r--r-- 78 mateusz 17 lis 20:49 󱁻 build/bin/i686-w64-windows-gnu.cfg
.rw-r--r-- 68 mateusz 17 lis 20:49 󱁻 build/bin/mingw32-common.cfg
lrwxrwxrwx  - mateusz 17 lis 20:49 󱁻 build/bin/x86_64-pc-windows-gnu.cfg -> x86_64-w64-windows-gnu.cfg
.rw-r--r-- 80 mateusz 17 lis 20:49 󱁻 build/bin/x86_64-w64-windows-gnu.cfg
```