### PR TITLE
[WIP] Add flang (Fortran) compiler support

### DIFF
--- a/build-all.sh
+++ b/build-all.sh
@@ -236,6 +236,7 @@ fi
 ./build-mingw-w64.sh $PREFIX $MINGW_ARGS $CFGUARD_ARGS
 ./build-compiler-rt.sh $PREFIX $CFGUARD_ARGS
 ./build-libcxx.sh $PREFIX $CFGUARD_ARGS
+./build-flang-rt.sh $PREFIX $CFGUARD_ARGS
 ./build-mingw-w64-libraries.sh $PREFIX $CFGUARD_ARGS
 ./build-compiler-rt.sh $PREFIX --build-sanitizers # CFGUARD_ARGS intentionally omitted
 ./build-openmp.sh $PREFIX $CFGUARD_ARGS

--- a/build-flang-rt.sh
+++ b/build-flang-rt.sh
@@ -1,0 +1,135 @@
+#!/bin/sh
+#
+# Copyright (c) 2018 Martin Storsjo
+#
+# Permission to use, copy, modify, and/or distribute this software for any
+# purpose with or without fee is hereby granted, provided that the above
+# copyright notice and this permission notice appear in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+# WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+# ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+# OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+set -e
+
+BUILD_STATIC=ON
+# Shared library not supported on Windows yet per flang-rt CMakeLists.txt
+BUILD_SHARED=OFF
+CFGUARD_CFLAGS="-mguard=cf"
+
+while [ $# -gt 0 ]; do
+    if [ "$1" = "--disable-static" ]; then
+        BUILD_STATIC=OFF
+    elif [ "$1" = "--enable-static" ]; then
+        BUILD_STATIC=ON
+    elif [ "$1" = "--enable-cfguard" ]; then
+        CFGUARD_CFLAGS="-mguard=cf"
+    elif [ "$1" = "--disable-cfguard" ]; then
+        CFGUARD_CFLAGS=
+    else
+        PREFIX="$1"
+    fi
+    shift
+done
+if [ -z "$PREFIX" ]; then
+    echo "$0 [--disable-static] [--enable-cfguard|--disable-cfguard] dest"
+    exit 1
+fi
+
+mkdir -p "$PREFIX"
+PREFIX="$(cd "$PREFIX" && pwd)"
+
+export PATH="$PREFIX/bin:$PATH"
+
+# i686 and armv7 are excluded due to compile-time asserts in flang-rt
+# arm64ec is excluded due to not building flang for it (unknown if it would work)
+: ${ARCHS:=${TOOLCHAIN_ARCHS-x86_64 aarch64}}
+
+CLANG_RESOURCE_DIR="$("$PREFIX/bin/clang" --print-resource-dir)"
+CLANG_VERSION=$(basename "$CLANG_RESOURCE_DIR")
+CLANG_MAJOR="${CLANG_VERSION%%.*}"
+
+if [ ! -d llvm-project/flang-rt ] || [ -n "$SYNC" ]; then
+    CHECKOUT_ONLY=1 ./build-llvm.sh
+fi
+
+# Find the Fortran compiler - prefer flang-new if available, otherwise use flang
+if [ -x "$PREFIX/bin/flang-new" ]; then
+    FLANG="$PREFIX/bin/flang-new"
+elif [ -x "$PREFIX/bin/flang" ]; then
+    FLANG="$PREFIX/bin/flang"
+else
+    echo "Error: No flang compiler found in $PREFIX/bin"
+    exit 1
+fi
+
+cd llvm-project
+
+cd runtimes
+
+if command -v ninja >/dev/null; then
+    CMAKE_GENERATOR="Ninja"
+else
+    : ${CORES:=$(nproc 2>/dev/null)}
+    : ${CORES:=$(sysctl -n hw.ncpu 2>/dev/null)}
+    : ${CORES:=4}
+
+    case $(uname) in
+    MINGW*)
+        CMAKE_GENERATOR="MSYS Makefiles"
+        ;;
+    esac
+fi
+
+for arch in $ARCHS; do
+    [ -z "$CLEAN" ] || rm -rf build-flang-rt-$arch
+    mkdir -p build-flang-rt-$arch
+    cd build-flang-rt-$arch
+    [ -n "$NO_RECONF" ] || rm -rf CMake*
+    cmake \
+        ${CMAKE_GENERATOR+-G} "$CMAKE_GENERATOR" \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_INSTALL_PREFIX="$PREFIX" \
+        -DCMAKE_C_COMPILER=$arch-w64-mingw32-clang \
+        -DCMAKE_CXX_COMPILER=$arch-w64-mingw32-clang++ \
+        -DCMAKE_Fortran_COMPILER="$FLANG" \
+        -DCMAKE_C_COMPILER_TARGET=$arch-w64-windows-gnu \
+        -DCMAKE_CXX_COMPILER_TARGET=$arch-w64-windows-gnu \
+        -DCMAKE_Fortran_COMPILER_TARGET=$arch-w64-windows-gnu \
+        -DCMAKE_SYSTEM_NAME=Windows \
+        -DCMAKE_C_COMPILER_WORKS=TRUE \
+        -DCMAKE_CXX_COMPILER_WORKS=TRUE \
+        -DCMAKE_Fortran_COMPILER_WORKS=TRUE \
+        -DCMAKE_Fortran_COMPILER_ID=LLVMFlang \
+        -DCMAKE_Fortran_COMPILER_ID_RUN=TRUE \
+        -DCMAKE_Fortran_SIMULATE_ID=GNU \
+        -DCMAKE_Fortran_COMPILER_SUPPORTS_F90=TRUE \
+        -DCMAKE_AR="$PREFIX/bin/llvm-ar" \
+        -DCMAKE_RANLIB="$PREFIX/bin/llvm-ranlib" \
+        -DLLVM_ENABLE_RUNTIMES="flang-rt" \
+        -DLLVM_DEFAULT_TARGET_TRIPLE=$arch-w64-windows-gnu \
+        -DLLVM_VERSION_MAJOR="$CLANG_MAJOR" \
+        -DFLANG_RT_ENABLE_STATIC=$BUILD_STATIC \
+        -DFLANG_RT_ENABLE_SHARED=$BUILD_SHARED \
+        -DFLANG_RT_INCLUDE_TESTS=OFF \
+        -DCMAKE_C_FLAGS_INIT="$CFGUARD_CFLAGS" \
+        -DCMAKE_CXX_FLAGS_INIT="$CFGUARD_CFLAGS" \
+        -DCMAKE_Fortran_FLAGS_INIT="--target=$arch-w64-windows-gnu --no-default-config" \
+        ..
+
+    cmake --build . ${CORES:+-j${CORES}}
+    cmake --install .
+
+    # Create symlink for the runtime library without the .static suffix
+    # Flang looks for libflang_rt.runtime.a but we build libflang_rt.runtime.static.a
+    FLANG_RT_DIR="$CLANG_RESOURCE_DIR/lib/$arch-w64-windows-gnu"
+    if [ -f "$FLANG_RT_DIR/libflang_rt.runtime.static.a" ] && [ ! -e "$FLANG_RT_DIR/libflang_rt.runtime.a" ]; then
+        ln -sf libflang_rt.runtime.static.a "$FLANG_RT_DIR/libflang_rt.runtime.a"
+    fi
+
+    cd ..
+done

--- a/build-llvm.sh
+++ b/build-llvm.sh
@@ -365,7 +365,7 @@ fi
 
 cd llvm-project/llvm
 
-PROJECTS="clang;lld"
+PROJECTS="clang;lld;flang"
 if [ -n "$LLDB" ]; then
     PROJECTS="$PROJECTS;lldb"
 fi

--- a/install-wrappers.sh
+++ b/install-wrappers.sh
@@ -90,6 +90,13 @@ if [ -n "${HOST_CLANG}" ]; then
     ln -sf clang $PREFIX/bin/clang++
     ln -sf clang $PREFIX/bin/clang-cpp
 
+    HOST_FLANG_EXE=$(PATH=$llvmexec command -v flang-new || true)
+    if [ -n "$HOST_FLANG_EXE" ]; then
+        printf '#!/bin/sh\nsr=$(dirname "$(dirname "$(readlink -f "$0")")")\nexec %s -resource-dir="$sr"%s --sysroot="$sr" --config-system-dir="$sr"/bin "$@"\n' "$HOST_FLANG_EXE" "$clangres" > $PREFIX/bin/flang
+        chmod 755 $PREFIX/bin/flang
+        echo "Using existing flang $HOST_FLANG_EXE"
+    fi
+
     echo "Using existing clang $HOST_CLANG_EXE ($HOST_CLANG_VER)"
     $PREFIX/bin/clang -v
 
@@ -152,7 +159,7 @@ fi
 cd "$PREFIX/bin"
 for arch in $ARCHS; do
     for target_os in $TARGET_OSES; do
-        for exec in clang clang++ gcc g++ c++ as; do
+        for exec in clang clang++ gcc g++ c++ as flang gfortran; do
             ln -sf clang-target-wrapper$CTW_SUFFIX $arch-w64-$target_os-$exec$CTW_LINK_SUFFIX
         done
         ln -sf $CSDW $arch-w64-$target_os-clang-scan-deps$CTW_LINK_SUFFIX
@@ -195,7 +202,7 @@ if [ -n "$EXEEXT" ]; then
     # we are installing wrappers for.
     case $ARCHS in
     *$HOST_ARCH*)
-        for exec in clang clang++ gcc g++ c++ addr2line ar dlltool ranlib nm objcopy readelf size strings strip windres clang-scan-deps; do
+        for exec in clang clang++ gcc g++ c++ addr2line ar dlltool ranlib nm objcopy readelf size strings strip windres clang-scan-deps flang gfortran; do
             ln -sf $HOST-$exec$EXEEXT $exec$EXEEXT
         done
         for exec in cc c99 c11; do

--- a/strip-llvm.sh
+++ b/strip-llvm.sh
@@ -149,7 +149,7 @@ rm -f *.dll.a
 rm -f lib*.a
 for i in *.so* *.dylib* cmake; do
     case $i in
-    liblldb*|libclang-cpp*|libLLVM*)
+    liblldb*|libclang-cpp*|libLLVM*|libMLIR*|libFortran*|libflang*)
         ;;
     *)
         rm -rf $i


### PR DESCRIPTION
This attempts to add the configuration needed to build and use `flang` on Windows. Mostly written by Claude since I don't have much familiarity with either this code or with flang/flang-rt specifically, so some things are probably done sub-optimally. The main fact here is just that this worked to build a `flang` cross compiler and relevant runtime libraries and then the result was able to build OpenBLAS and pass all of its self tests. Unfortunately there are a very small number of mistakes in flang-rt in v21 that mean it currently only supports building with MSVC headers, but that should get resolved soon in upstream llvm.

Change overview:
- Add flang to LLVM_ENABLE_PROJECTS in build-llvm.sh
- Add build-flang-rt.sh to build the Fortran runtime library
- Update install-wrappers.sh to create flang/gfortran symlinks
- Update clang-target-wrapper.c and clang-target-wrapper.sh to handle
  flang driver:
  - Uses flang binary directly (instead of clang --driver-mode=flang)
  - Adds --no-default-config to avoid C++-specific flags from config
    files causing flang to error
  - Add -rtlib=compiler-rt to use compiler-rt instead of libgcc (this
    seemed to make the linker complain about an unused argument, but
    also fixes the build to stop linking against -lgcc).
  - Pass through -fc1 invocations directly to avoid breaking frontend
    calls (calling `*flang` calls `*flang -fc1`, which got confused if
    we prepend any other arguments).
- Update strip-llvm.sh to preserve libMLIR, libFortran, and libflang
  shared libs.

Note: i686 and armv7 are excluded from flang-rt due to compile-time
asserts that failed due to 32-bit mistakes. The arm64ec is excluded as
we haven't tested if flang could be built for it.

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
Refs: #146, #163 